### PR TITLE
Feature/challenges UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",
-        "vite": "^5.4.19",
+        "vite": "^5.4.21",
         "vitest": "^3.2.4"
       }
     },
@@ -8220,9 +8220,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.19",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
-      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19",
+    "vite": "^5.4.21",
     "vitest": "^3.2.4"
   }
 }

--- a/prompts/challenge_ui.md
+++ b/prompts/challenge_ui.md
@@ -1,0 +1,495 @@
+# Challenges Feature - Implementation Plan
+
+## Overview
+
+Add a **Challenges** feature to GamiphyAI where users can create requests for datasets to automate new tasks using robots. Other users can browse challenges on the marketplace and propose matching datasets for compensation.
+
+## Architecture
+
+### Data Model
+
+#### `challenges` table (Supabase/PostgreSQL)
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | `uuid` | `gen_random_uuid()` | PK |
+| `user_id` | `uuid` | - | FK to `auth.users`, challenge creator |
+| `title` | `text` | - | Challenge title |
+| `description` | `text` | `''` | Rich description of the task |
+| `status` | `text` | `'draft'` | `draft` / `active` / `inactive` / `closed` |
+| `compensation_amount` | `integer` | `0` | Amount in smallest currency unit (cents/won) |
+| `compensation_per` | `text` | `'dataset'` | `dataset` or `challenge` (per-dataset vs lump sum) |
+| `currency` | `text` | `'USD'` | Currency code |
+| `deadline` | `timestamptz` | `null` | Optional submission deadline |
+| `constraints` | `text` | `''` | Technical constraints (robot type, format, etc.) |
+| `conditions` | `text` | `''` | Acceptance conditions for datasets |
+| `tags` | `text[]` | `'{}'` | Searchable tags |
+| `submission_count` | `integer` | `0` | Number of dataset proposals received |
+| `created_at` | `timestamptz` | `now()` | |
+| `updated_at` | `timestamptz` | `now()` | |
+
+#### `challenge_media` table
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | `uuid` | `gen_random_uuid()` | PK |
+| `challenge_id` | `uuid` | - | FK to `challenges` |
+| `user_id` | `uuid` | - | FK to `auth.users` (for storage path) |
+| `storage_path` | `text` | - | Path in Supabase Storage |
+| `file_name` | `text` | - | Original filename |
+| `content_type` | `text` | - | MIME type (video/mp4, image/png, etc.) |
+| `size_bytes` | `bigint` | `null` | File size |
+| `sort_order` | `integer` | `0` | Display ordering |
+| `created_at` | `timestamptz` | `now()` | |
+
+#### `challenge_submissions` table (for dataset proposals)
+
+| Column | Type | Default | Notes |
+|--------|------|---------|-------|
+| `id` | `uuid` | `gen_random_uuid()` | PK |
+| `challenge_id` | `uuid` | - | FK to `challenges` |
+| `dataset_id` | `uuid` | - | FK to `datasets` |
+| `submitter_id` | `uuid` | - | FK to `auth.users` |
+| `message` | `text` | `''` | Proposal message |
+| `status` | `text` | `'pending'` | `pending` / `accepted` / `rejected` |
+| `created_at` | `timestamptz` | `now()` | |
+
+#### Storage bucket: `challenge-media`
+- Path pattern: `{user_id}/{challenge_id}/{filename}`
+- Private bucket with RLS policies matching owner
+
+#### RLS Policies
+
+**challenges:**
+- `owner_crud`: Authenticated users can CRUD their own challenges (`auth.uid() = user_id`)
+- `public_read_active`: Anyone can SELECT where `status = 'active'`
+
+**challenge_media:**
+- `owner_crud`: Authenticated users can CRUD their own media (`auth.uid() = user_id`)
+- `public_read`: Anyone can SELECT media for active challenges (via join or direct)
+
+**challenge_submissions:**
+- `submitter_crud`: Authenticated users can INSERT/SELECT their own submissions
+- `challenge_owner_read`: Challenge owners can SELECT submissions for their challenges
+
+---
+
+### TypeScript Types (`src/types/index.ts`)
+
+```typescript
+export interface Challenge {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  status: "draft" | "active" | "inactive" | "closed";
+  compensation_amount: number;
+  compensation_per: "dataset" | "challenge";
+  currency: string;
+  deadline: string | null;
+  constraints: string;
+  conditions: string;
+  tags: string[];
+  submission_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChallengeMedia {
+  id: string;
+  challenge_id: string;
+  user_id: string;
+  storage_path: string;
+  file_name: string;
+  content_type: string;
+  size_bytes: number | null;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface ChallengeSubmission {
+  id: string;
+  challenge_id: string;
+  dataset_id: string;
+  submitter_id: string;
+  message: string;
+  status: "pending" | "accepted" | "rejected";
+  created_at: string;
+}
+
+export interface EnrichedChallenge extends Challenge {
+  creator_name: string;
+  media: ChallengeMedia[];
+}
+```
+
+---
+
+### Service Layer
+
+#### `src/services/challengeService.ts`
+
+```typescript
+const challengeService = {
+  // List all active challenges (for marketplace)
+  async listActive(): Promise<Challenge[]>;
+
+  // List enriched challenges (with creator name + media)
+  async listEnriched(): Promise<EnrichedChallenge[]>;
+
+  // List user's own challenges (for dashboard, all statuses)
+  async listMine(): Promise<Challenge[]>;
+
+  // Get single challenge by ID
+  async get(id: string): Promise<Challenge | undefined>;
+
+  // Create new challenge (draft status)
+  async create(data: Omit<Challenge, 'id' | 'submission_count' | 'created_at' | 'updated_at'>): Promise<Challenge>;
+
+  // Update challenge (save draft progress or edit)
+  async update(id: string, updates: Partial<Challenge>): Promise<Challenge>;
+
+  // Publish challenge (set status to 'active')
+  async publish(id: string): Promise<Challenge>;
+
+  // Toggle active/inactive
+  async setStatus(id: string, status: 'active' | 'inactive' | 'closed'): Promise<Challenge>;
+
+  // Delete draft challenge
+  async deleteDraft(id: string): Promise<void>;
+};
+```
+
+#### `src/services/challengeMediaService.ts`
+
+```typescript
+const challengeMediaService = {
+  // Upload media file to Supabase Storage + create record
+  async upload(challengeId: string, userId: string, file: File): Promise<ChallengeMedia>;
+
+  // List media for a challenge
+  async list(challengeId: string): Promise<ChallengeMedia[]>;
+
+  // Get signed URL for a media file
+  async getSignedUrl(storagePath: string): Promise<string>;
+
+  // Delete media file
+  async delete(mediaId: string, storagePath: string): Promise<void>;
+
+  // Reorder media
+  async reorder(mediaIds: string[]): Promise<void>;
+};
+```
+
+#### `src/services/challengeSubmissionService.ts`
+
+```typescript
+const challengeSubmissionService = {
+  // Submit a dataset to a challenge
+  async submit(data: { challenge_id: string; dataset_id: string; message: string }): Promise<ChallengeSubmission>;
+
+  // List submissions for a challenge (owner view)
+  async listForChallenge(challengeId: string): Promise<ChallengeSubmission[]>;
+
+  // List user's own submissions
+  async listMine(): Promise<ChallengeSubmission[]>;
+
+  // Update submission status (challenge owner)
+  async updateStatus(id: string, status: 'accepted' | 'rejected'): Promise<void>;
+};
+```
+
+---
+
+### Frontend Components
+
+#### New Components
+
+1. **`ChallengeCard.tsx`** - Marketplace card for challenges (similar to `MarketplaceCard`)
+   - Shows: thumbnail (first media), title, description snippet, compensation badge, deadline, tags, creator
+   - Compensation badge: green for per-dataset, blue for lump sum
+   - Deadline indicator: shows days remaining, red if < 3 days
+   - Submission count badge
+
+2. **`CreateChallengeModal.tsx`** - Multi-step modal for creating/editing challenges
+   - Step 1: Basic info (title, description)
+   - Step 2: Media upload (drag & drop videos/images)
+   - Step 3: Compensation & conditions (amount, per-type, currency, deadline, constraints, conditions)
+   - Step 4: Tags & review
+   - "Save Draft" button available at every step
+   - "Publish" button on final step
+   - Uses existing Dialog, Button, Input, Textarea, Select from shadcn/ui
+
+3. **`ChallengeStatusBadge.tsx`** - Status indicator component
+   - draft: gray, active: green, inactive: yellow, closed: red
+
+4. **`ChallengeListCard.tsx`** - Dashboard list item (similar to `DatasetListCard`)
+   - Shows: title, status badge, compensation, deadline, submission count
+   - Actions: Edit, Publish/Unpublish, Delete (draft only)
+
+5. **`ChallengeMediaUpload.tsx`** - Media upload zone for challenges
+   - Drag & drop zone (reuses patterns from `FileUploadZone`)
+   - Accepts: video/*, image/*
+   - Shows thumbnails/previews of uploaded files
+   - Reorder via sort_order
+   - Delete individual files
+
+6. **`SubmitDatasetModal.tsx`** - Modal for submitting a dataset to a challenge
+   - Select from user's own datasets
+   - Add a proposal message
+   - Submit button
+
+#### Modified Components
+
+1. **`MarketplacePage.tsx`** - Add tab navigation: "Datasets" | "Challenges"
+   - Default tab: Datasets (current behavior)
+   - Challenges tab: grid of ChallengeCards
+   - Shared search bar filters both tabs
+   - Tag filtering works across both
+   - Tab state preserved in URL query param (`?tab=challenges`)
+
+2. **`DashboardPage.tsx`** - Add Challenges section
+   - New stats card: "Challenges" count
+   - "My Challenges" section below datasets
+   - "Create Challenge" button (opens CreateChallengeModal)
+   - List of user's challenges with ChallengeListCard
+
+3. **`Navbar.tsx`** - No changes needed (marketplace link already exists)
+
+#### New Pages
+
+1. **`ChallengeDetailPage.tsx`** (`/marketplace/challenges/:id`)
+   - Full challenge description with rich text
+   - Media gallery (video player + image gallery)
+   - Compensation details
+   - Deadline countdown
+   - Constraints and conditions
+   - "Submit Dataset" button (for other authenticated users)
+   - Status management (for owner): toggle active/inactive
+   - Submissions list (for owner)
+
+2. **`EditChallengePage.tsx`** (`/dashboard/challenges/:id`)
+   - Full edit form (reuses CreateChallengeModal logic as a page)
+   - Save progress, publish, manage status
+   - Media management
+
+---
+
+### Routes (`App.tsx`)
+
+```
+/marketplace                       - MarketplacePage (with tabs)
+/marketplace/challenges/:id        - ChallengeDetailPage (public, active only)
+/dashboard                         - DashboardPage (with challenges section)
+/dashboard/challenges/new          - EditChallengePage (create mode)
+/dashboard/challenges/:id          - EditChallengePage (edit mode)
+```
+
+---
+
+### User Flows
+
+#### Creating a Challenge
+1. User navigates to Dashboard
+2. Clicks "Create Challenge" button
+3. Redirected to `/dashboard/challenges/new`
+4. Fills in title, description
+5. Uploads videos/images showing the task
+6. Sets compensation (amount, per-dataset or per-challenge, currency)
+7. Sets deadline (optional)
+8. Adds constraints and conditions
+9. Adds tags
+10. Can "Save Draft" at any point (creates/updates with status='draft')
+11. Clicks "Publish" to set status='active' and make visible on marketplace
+
+#### Browsing Challenges
+1. User navigates to Marketplace
+2. Sees tab navigation: "Datasets" | "Challenges"
+3. Clicks "Challenges" tab
+4. Sees grid of active challenges with ChallengeCards
+5. Can search and filter by tags
+6. Clicks a challenge card to see full details
+
+#### Submitting a Dataset to a Challenge
+1. User views a challenge detail page
+2. Clicks "Submit Dataset"
+3. Selects from their uploaded datasets
+4. Adds a proposal message
+5. Submits — creates a challenge_submission record
+6. Challenge owner can see submissions and accept/reject
+
+#### Managing Challenge Status
+1. Owner navigates to Dashboard > My Challenges
+2. Can toggle status: active -> inactive (stop receiving submissions)
+3. Can reactivate: inactive -> active
+4. Can close: any -> closed (permanent)
+
+---
+
+## Unit Tests
+
+### `src/test/unit/services/challengeService.test.ts`
+
+```
+describe("challengeService")
+  describe("listActive")
+    - returns array of active challenges
+    - returns empty array when no challenges exist
+
+  describe("listMine")
+    - returns user's challenges of all statuses
+
+  describe("get")
+    - returns challenge by id
+    - returns undefined for non-existent id
+
+  describe("create")
+    - creates challenge with draft status
+    - includes all provided fields
+
+  describe("update")
+    - updates specified fields
+    - updates updated_at timestamp
+
+  describe("publish")
+    - sets status to active
+
+  describe("setStatus")
+    - toggles between active and inactive
+    - sets to closed
+
+  describe("deleteDraft")
+    - deletes draft challenge
+```
+
+### `src/test/unit/services/challengeMediaService.test.ts`
+
+```
+describe("challengeMediaService")
+  describe("upload")
+    - uploads file to storage and creates record
+    - returns ChallengeMedia with storage path
+
+  describe("list")
+    - returns media for challenge ordered by sort_order
+
+  describe("getSignedUrl")
+    - returns signed URL string
+
+  describe("delete")
+    - removes storage file and database record
+```
+
+### `src/test/unit/services/challengeSubmissionService.test.ts`
+
+```
+describe("challengeSubmissionService")
+  describe("submit")
+    - creates submission with pending status
+
+  describe("listForChallenge")
+    - returns submissions for a given challenge
+
+  describe("listMine")
+    - returns user's own submissions
+
+  describe("updateStatus")
+    - updates submission status to accepted/rejected
+```
+
+### `src/test/unit/components/ChallengeCard.test.tsx`
+
+```
+describe("ChallengeCard")
+  - renders challenge title and description
+  - shows compensation badge with correct formatting
+  - shows deadline when set
+  - shows "No deadline" when deadline is null
+  - shows submission count
+  - renders tags
+  - links to challenge detail page
+  - shows creator name
+```
+
+### `src/test/unit/components/ChallengeStatusBadge.test.tsx`
+
+```
+describe("ChallengeStatusBadge")
+  - renders "Draft" with gray styling
+  - renders "Active" with green styling
+  - renders "Inactive" with yellow styling
+  - renders "Closed" with red styling
+```
+
+### `src/test/unit/components/ChallengeListCard.test.tsx`
+
+```
+describe("ChallengeListCard")
+  - renders title and status badge
+  - shows edit button
+  - shows delete button only for draft status
+  - shows publish button for draft challenges
+  - shows activate/deactivate toggle for published challenges
+```
+
+### `src/test/integration/marketplace-challenges.test.tsx`
+
+```
+describe("MarketplacePage - Challenges Tab")
+  - renders Datasets tab by default
+  - switches to Challenges tab on click
+  - displays challenge cards in grid
+  - filters challenges by search query
+  - filters challenges by tag
+  - shows empty state when no challenges match
+  - preserves tab state in URL
+```
+
+### `src/test/integration/dashboard-challenges.test.tsx`
+
+```
+describe("DashboardPage - Challenges Section")
+  - shows challenge count in stats
+  - renders Create Challenge button
+  - lists user's challenges
+  - shows empty state when no challenges
+```
+
+### `src/test/integration/challenge-detail.test.tsx`
+
+```
+describe("ChallengeDetailPage")
+  - renders challenge title and description
+  - displays media gallery
+  - shows compensation details
+  - shows deadline countdown
+  - shows Submit Dataset button for non-owner authenticated users
+  - hides Submit Dataset button for challenge owner
+  - shows status controls for owner
+```
+
+---
+
+## Implementation Order
+
+1. **Database**: Create Supabase migration (tables, RLS, storage bucket)
+2. **Types**: Add Challenge interfaces to `src/types/index.ts`
+3. **Services**: Implement challengeService, challengeMediaService, challengeSubmissionService
+4. **Components**: Build ChallengeCard, ChallengeStatusBadge, ChallengeListCard, ChallengeMediaUpload
+5. **Pages**: Build ChallengeDetailPage, EditChallengePage
+6. **Integration**: Update MarketplacePage (tabs), DashboardPage (challenges section)
+7. **Routes**: Add new routes to App.tsx
+8. **Tests**: Unit tests for services, component tests, integration tests
+9. **Polish**: Responsive design, loading states, error handling
+
+## Design Consistency
+
+All new components follow existing patterns:
+- **Cards**: Use `rounded-2xl border border-border/40 bg-card/50 backdrop-blur-sm` pattern
+- **Badges**: Use `px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider` pattern
+- **Icons**: Lucide React icons consistently
+- **Colors**: Primary (cyan/teal) for main actions, Secondary (purple) for accents
+- **Transitions**: `transition-all duration-300` or `duration-500` for hover effects
+- **Neon glow**: `shadow-[0_0_40px_hsl(var(--primary)/0.12)]` on hover
+- **Typography**: DM Sans for body, JetBrains Mono for code/prices
+- **Layout**: Container with `mx-auto px-6`, responsive grid `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`

--- a/prompts/challenge_ui_final.md
+++ b/prompts/challenge_ui_final.md
@@ -1,0 +1,739 @@
+# Challenges Feature - Final Implementation Plan
+
+> Integrates feedback from Codex GPT-5.4 review on schema constraints, RLS precision, frontend architecture, UX edge cases, test coverage, and security.
+
+## Overview
+
+Add a **Challenges** feature to GamiphyAI where users can create requests for datasets to automate new tasks using robots. Other users browse challenges on the marketplace and propose matching datasets for compensation. **Compensation is display-only in v1** -- actual payout workflows are deferred to a future iteration.
+
+---
+
+## 1. Database Schema
+
+### 1.1 `challenges` table
+
+```sql
+CREATE TABLE public.challenges (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid        NOT NULL,
+  title           text        NOT NULL CHECK (length(trim(title)) > 0),
+  description     text        NOT NULL DEFAULT '',
+  status          text        NOT NULL DEFAULT 'draft'
+                              CHECK (status IN ('draft','active','inactive','closed')),
+  compensation_amount integer NOT NULL DEFAULT 0 CHECK (compensation_amount >= 0),
+  compensation_per text       NOT NULL DEFAULT 'dataset'
+                              CHECK (compensation_per IN ('dataset','challenge')),
+  currency        text        NOT NULL DEFAULT 'USD'
+                              CHECK (currency IN ('USD','KRW')),
+  deadline        timestamptz,
+  constraints     text        NOT NULL DEFAULT '',
+  conditions      text        NOT NULL DEFAULT '',
+  tags            text[]      NOT NULL DEFAULT '{}',
+  submission_count integer    NOT NULL DEFAULT 0,
+  published_at    timestamptz,
+  closed_at       timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX idx_challenges_user    ON public.challenges (user_id, created_at DESC);
+CREATE INDEX idx_challenges_active  ON public.challenges (created_at DESC) WHERE status = 'active';
+CREATE INDEX idx_challenges_deadline ON public.challenges (deadline) WHERE deadline IS NOT NULL;
+CREATE INDEX idx_challenges_tags    ON public.challenges USING GIN (tags);
+
+ALTER TABLE public.challenges ENABLE ROW LEVEL SECURITY;
+
+-- Owner full CRUD
+CREATE POLICY "owner_crud" ON public.challenges FOR ALL
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Public can read active challenges
+CREATE POLICY "public_read_active" ON public.challenges FOR SELECT
+  TO anon, authenticated
+  USING (status = 'active');
+```
+
+**Status transition trigger** -- enforces valid transitions and sets timestamps:
+
+```sql
+CREATE OR REPLACE FUNCTION public.validate_challenge_status_transition()
+RETURNS trigger AS $$
+BEGIN
+  -- Only validate if status changed
+  IF OLD.status = NEW.status THEN RETURN NEW; END IF;
+
+  -- Allowed transitions
+  IF NOT (
+    (OLD.status = 'draft'    AND NEW.status IN ('active','closed')) OR
+    (OLD.status = 'active'   AND NEW.status IN ('inactive','closed')) OR
+    (OLD.status = 'inactive' AND NEW.status IN ('active','closed'))
+  ) THEN
+    RAISE EXCEPTION 'Invalid status transition from % to %', OLD.status, NEW.status;
+  END IF;
+
+  -- Set timestamps
+  IF NEW.status = 'active' AND OLD.status = 'draft' THEN
+    NEW.published_at := now();
+  END IF;
+  IF NEW.status = 'closed' THEN
+    NEW.closed_at := now();
+  END IF;
+  NEW.updated_at := now();
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_challenge_status
+  BEFORE UPDATE ON public.challenges
+  FOR EACH ROW EXECUTE FUNCTION public.validate_challenge_status_transition();
+```
+
+**Submission count trigger** -- keeps `submission_count` accurate:
+
+```sql
+CREATE OR REPLACE FUNCTION public.update_challenge_submission_count()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.challenges SET submission_count = submission_count + 1 WHERE id = NEW.challenge_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.challenges SET submission_count = submission_count - 1 WHERE id = OLD.challenge_id;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_submission_count
+  AFTER INSERT OR DELETE ON public.challenge_submissions
+  FOR EACH ROW EXECUTE FUNCTION public.update_challenge_submission_count();
+```
+
+### 1.2 `challenge_media` table
+
+```sql
+CREATE TABLE public.challenge_media (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  challenge_id  uuid        NOT NULL REFERENCES public.challenges(id) ON DELETE CASCADE,
+  user_id       uuid        NOT NULL,
+  storage_path  text        NOT NULL,
+  file_name     text        NOT NULL,
+  content_type  text        NOT NULL,
+  size_bytes    bigint,
+  sort_order    integer     NOT NULL DEFAULT 0,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_challenge_media_order ON public.challenge_media (challenge_id, sort_order);
+
+ALTER TABLE public.challenge_media ENABLE ROW LEVEL SECURITY;
+
+-- Owner full CRUD
+CREATE POLICY "owner_crud" ON public.challenge_media FOR ALL
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Public can read media for active challenges
+CREATE POLICY "public_read_active" ON public.challenge_media FOR SELECT
+  TO anon, authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.challenges c
+    WHERE c.id = challenge_id AND c.status = 'active'
+  ));
+```
+
+### 1.3 `challenge_submissions` table
+
+```sql
+CREATE TABLE public.challenge_submissions (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  challenge_id  uuid        NOT NULL REFERENCES public.challenges(id) ON DELETE CASCADE,
+  dataset_id    uuid        NOT NULL REFERENCES public.datasets(id),
+  submitter_id  uuid        NOT NULL,
+  message       text        NOT NULL DEFAULT '',
+  status        text        NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending','accepted','rejected')),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(challenge_id, dataset_id)
+);
+
+CREATE INDEX idx_submissions_challenge ON public.challenge_submissions (challenge_id, created_at DESC);
+CREATE INDEX idx_submissions_submitter ON public.challenge_submissions (submitter_id, created_at DESC);
+
+ALTER TABLE public.challenge_submissions ENABLE ROW LEVEL SECURITY;
+
+-- Submitter can view own submissions
+CREATE POLICY "submitter_select" ON public.challenge_submissions FOR SELECT
+  TO authenticated
+  USING (auth.uid() = submitter_id);
+
+-- Submitter can insert (only to active challenges, own datasets, not own challenge)
+CREATE POLICY "submitter_insert" ON public.challenge_submissions FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = submitter_id
+    AND EXISTS (
+      SELECT 1 FROM public.challenges c
+      WHERE c.id = challenge_id AND c.status = 'active' AND c.user_id != auth.uid()
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.datasets d
+      WHERE d.id = dataset_id AND d.user_id = auth.uid() AND d.status = 'ready'
+    )
+  );
+
+-- Challenge owner can view submissions for their challenges
+CREATE POLICY "owner_select" ON public.challenge_submissions FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.challenges c
+    WHERE c.id = challenge_id AND c.user_id = auth.uid()
+  ));
+
+-- Challenge owner can update submission status
+CREATE POLICY "owner_update_status" ON public.challenge_submissions FOR UPDATE
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.challenges c
+    WHERE c.id = challenge_id AND c.user_id = auth.uid()
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.challenges c
+    WHERE c.id = challenge_id AND c.user_id = auth.uid()
+  ));
+```
+
+### 1.4 Storage Bucket
+
+```sql
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('challenge-media', 'challenge-media', false);
+
+-- Owner upload (path: user_id/challenge_id/uuid-filename)
+CREATE POLICY "owner_upload" ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'challenge-media'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Owner manage
+CREATE POLICY "owner_manage" ON storage.objects FOR ALL
+  TO authenticated
+  USING (
+    bucket_id = 'challenge-media'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Public read for active challenges (via signed URLs, not direct)
+CREATE POLICY "public_read" ON storage.objects FOR SELECT
+  TO anon, authenticated
+  USING (bucket_id = 'challenge-media');
+```
+
+---
+
+## 2. TypeScript Types (`src/types/index.ts`)
+
+```typescript
+export interface Challenge {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  status: "draft" | "active" | "inactive" | "closed";
+  compensation_amount: number;
+  compensation_per: "dataset" | "challenge";
+  currency: string;
+  deadline: string | null;
+  constraints: string;
+  conditions: string;
+  tags: string[];
+  submission_count: number;
+  published_at: string | null;
+  closed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChallengeMedia {
+  id: string;
+  challenge_id: string;
+  user_id: string;
+  storage_path: string;
+  file_name: string;
+  content_type: string;
+  size_bytes: number | null;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface ChallengeSubmission {
+  id: string;
+  challenge_id: string;
+  dataset_id: string;
+  submitter_id: string;
+  message: string;
+  status: "pending" | "accepted" | "rejected";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EnrichedChallenge extends Challenge {
+  creator_name: string;
+  preview_url: string | null; // Single preview image/video for card
+}
+```
+
+---
+
+## 3. Service Layer
+
+### 3.1 `src/services/challengeService.ts`
+
+All methods use Supabase client. Privileged fields (`user_id`, `submission_count`, `published_at`, `closed_at`) are never set client-side.
+
+```typescript
+const challengeService = {
+  // Marketplace: list active challenges with creator names + first media preview
+  async listEnriched(): Promise<EnrichedChallenge[]>;
+
+  // Dashboard: list user's own challenges (all statuses)
+  async listMine(): Promise<Challenge[]>;
+
+  // Single challenge by ID
+  async get(id: string): Promise<Challenge | undefined>;
+
+  // Create draft
+  async create(data: {
+    title: string; description: string; compensation_amount: number;
+    compensation_per: "dataset"|"challenge"; currency: string;
+    deadline: string|null; constraints: string; conditions: string; tags: string[];
+  }): Promise<Challenge>;
+
+  // Save draft progress / edit
+  async update(id: string, updates: Partial<Omit<Challenge,
+    'id'|'user_id'|'submission_count'|'published_at'|'closed_at'|'created_at'|'updated_at'
+  >>): Promise<Challenge>;
+
+  // Publish (draft -> active)
+  async publish(id: string): Promise<Challenge>;
+
+  // Toggle active/inactive
+  async setStatus(id: string, status: 'active'|'inactive'|'closed'): Promise<Challenge>;
+
+  // Delete (draft only, enforced by service check)
+  async deleteDraft(id: string): Promise<void>;
+};
+```
+
+### 3.2 `src/services/challengeMediaService.ts`
+
+Storage path: `{user_id}/{challenge_id}/{uuid}-{sanitized_filename}`
+
+```typescript
+const challengeMediaService = {
+  // Upload file to storage + create DB record
+  async upload(challengeId: string, userId: string, file: File): Promise<ChallengeMedia>;
+
+  // List media for a challenge (ordered by sort_order)
+  async list(challengeId: string): Promise<ChallengeMedia[]>;
+
+  // Get signed URL (short TTL)
+  async getSignedUrl(storagePath: string): Promise<string>;
+
+  // Delete file + record
+  async delete(mediaId: string, storagePath: string): Promise<void>;
+
+  // Reorder
+  async reorder(items: { id: string; sort_order: number }[]): Promise<void>;
+};
+```
+
+### 3.3 `src/services/challengeSubmissionService.ts`
+
+```typescript
+const challengeSubmissionService = {
+  // Submit dataset to challenge
+  async submit(data: {
+    challenge_id: string; dataset_id: string; message: string;
+  }): Promise<ChallengeSubmission>;
+
+  // List for challenge (owner view)
+  async listForChallenge(challengeId: string): Promise<ChallengeSubmission[]>;
+
+  // List user's own submissions
+  async listMine(): Promise<ChallengeSubmission[]>;
+
+  // Owner: accept/reject
+  async updateStatus(id: string, status: 'accepted'|'rejected'): Promise<void>;
+};
+```
+
+---
+
+## 4. Frontend Architecture
+
+### 4.1 Component Hierarchy
+
+Following Codex feedback: page-based editor, extracted panels, React Query for server state.
+
+```
+MarketplacePage
+  MarketplaceHeader (hero, search bar)
+  MarketplaceTabs ("Datasets" | "Challenges")
+  DatasetMarketplacePanel (existing grid)
+  ChallengeMarketplacePanel
+    ChallengeCard[] (grid of active challenges)
+
+DashboardPage
+  (existing stats + datasets)
+  MyChallengesSection
+    "Create Challenge" button
+    ChallengeListCard[] (user's challenges)
+
+ChallengeEditorPage (/dashboard/challenges/new | /dashboard/challenges/:id)
+  ChallengeForm (react-hook-form + zod validation)
+    Step 1: BasicInfoFields (title, description)
+    Step 2: ChallengeMediaUpload (drag & drop)
+    Step 3: CompensationFields (amount, per-type, currency, deadline, constraints, conditions)
+    Step 4: TagsAndReview (tags, pre-publish checklist, preview)
+  "Save Draft" + "Publish" actions
+
+ChallengeDetailPage (/marketplace/challenges/:id)
+  ChallengeMediaGallery (video player + image grid)
+  ChallengeInfo (description, constraints, conditions)
+  CompensationBadge
+  DeadlineCountdown
+  SubmitDatasetModal (for other users)
+  SubmissionsPanel (for owner only)
+  StatusControls (for owner only)
+```
+
+### 4.2 New Components
+
+| Component | Purpose |
+|-----------|---------|
+| `ChallengeCard` | Marketplace card: preview thumbnail, title, compensation badge, deadline indicator, tags, creator, submission count |
+| `ChallengeListCard` | Dashboard list item: title, status badge, compensation, deadline, actions (edit/publish/toggle/delete) |
+| `ChallengeStatusBadge` | Status pill: draft=gray, active=green, inactive=yellow, closed=red |
+| `ChallengeForm` | Multi-step form with react-hook-form + zod. Save draft at any step. Pre-publish checklist on final step. |
+| `ChallengeMediaUpload` | Drag-drop zone for video/image. Shows previews. Reorder. Delete. Max 10 files, 100MB each. |
+| `ChallengeMediaGallery` | Public detail: video player + image thumbnails |
+| `CompensationBadge` | Shows amount + per-type: "per dataset" or "lump sum" |
+| `DeadlineCountdown` | Shows days remaining. Red if < 3 days. "No deadline" if null. |
+| `SubmitDatasetModal` | Select from user's ready datasets (filtered: not already submitted, not own challenge). Message field. |
+| `SubmissionsPanel` | Owner view: list of submissions with accept/reject actions |
+| `MyChallengesSection` | Dashboard section with own challenges query, create button |
+| `ChallengeMarketplacePanel` | Marketplace panel with challenges grid, loading/empty states |
+| `DatasetMarketplacePanel` | Extracted from current MarketplacePage dataset grid |
+| `MarketplaceTabs` | Tab bar for Datasets/Challenges with URL sync |
+
+### 4.3 New Pages
+
+| Page | Route | Auth | Purpose |
+|------|-------|------|---------|
+| `ChallengeEditorPage` | `/dashboard/challenges/new` | Protected | Create new challenge |
+| `ChallengeEditorPage` | `/dashboard/challenges/:id` | Protected | Edit own challenge |
+| `ChallengeDetailPage` | `/marketplace/challenges/:id` | Public | View active challenge |
+
+### 4.4 Routes Addition (`App.tsx`)
+
+```tsx
+<Route path="/dashboard/challenges/new" element={<ProtectedRoute><ChallengeEditorPage /></ProtectedRoute>} />
+<Route path="/dashboard/challenges/:id" element={<ProtectedRoute><ChallengeEditorPage /></ProtectedRoute>} />
+<Route path="/marketplace/challenges/:id" element={<ChallengeDetailPage />} />
+```
+
+### 4.5 URL State
+
+MarketplacePage URL params: `?tab=datasets|challenges&q=searchterm&tag=tagname`
+
+---
+
+## 5. User Flows
+
+### 5.1 Creating a Challenge
+1. Dashboard -> "Create Challenge" button -> navigates to `/dashboard/challenges/new`
+2. ChallengeForm with 4 steps (can navigate freely between steps)
+3. "Save Draft" available at every step (creates/updates record with status='draft')
+4. Unsaved changes warning on browser navigation (beforeunload)
+5. Pre-publish checklist on Step 4:
+   - Title set (required)
+   - Description set (required)
+   - Compensation configured
+   - At least one condition or constraint
+6. "Publish" sets status to 'active', redirects to challenge detail page
+7. Challenge appears in marketplace
+
+### 5.2 Editing a Challenge
+1. Dashboard -> click challenge -> navigates to `/dashboard/challenges/:id`
+2. Same ChallengeForm, pre-populated with existing data
+3. Can edit all fields while draft
+4. Active challenges: can edit description, constraints, conditions, tags, deadline. Cannot change compensation.
+5. Save updates immediately
+
+### 5.3 Browsing Challenges (Marketplace)
+1. Marketplace page -> "Challenges" tab (URL: `?tab=challenges`)
+2. Grid of ChallengeCards for active challenges
+3. Search filters by title, description, tags
+4. Tag chips filter challenges
+5. Click card -> `/marketplace/challenges/:id`
+6. Empty state: "No challenges yet. Be the first to create one!"
+
+### 5.4 Challenge Detail (Public)
+1. Shows full description, media gallery, compensation, deadline, constraints, conditions
+2. Non-owner authenticated user: "Submit Dataset" button
+3. Owner: Status controls (Deactivate/Reactivate/Close) + Submissions panel
+4. Unauthenticated: "Sign in to submit a dataset" CTA
+5. Closed/inactive: "This challenge is no longer accepting submissions" banner
+
+### 5.5 Submitting a Dataset
+1. Click "Submit Dataset" on challenge detail
+2. Modal shows dropdown of user's eligible datasets (status='ready', not already submitted to this challenge)
+3. Message textarea for proposal
+4. Submit -> creates challenge_submission record
+5. Confirmation toast
+6. Duplicate prevention: already-submitted datasets hidden from dropdown
+
+### 5.6 Managing Status
+- Draft -> Active (via Publish on editor) -- sets `published_at`
+- Active -> Inactive (via toggle on detail/dashboard) -- stops new submissions
+- Inactive -> Active (via toggle) -- resumes submissions
+- Any -> Closed (via close button with confirmation dialog) -- permanent, sets `closed_at`
+
+### 5.7 Deadline Behavior
+- Deadline is optional
+- Display-only in v1: expired challenges remain visible but show "Deadline passed" badge
+- Submissions still technically allowed (enforcement deferred to v2)
+
+---
+
+## 6. Unit Tests
+
+### 6.1 `src/test/unit/services/challengeService.test.ts`
+
+```
+describe("challengeService")
+  describe("listEnriched")
+    - returns array of enriched challenges with creator_name and preview_url
+    - returns empty array when no active challenges
+    - handles missing profiles gracefully
+
+  describe("listMine")
+    - returns user's challenges of all statuses
+
+  describe("get")
+    - returns challenge by id
+    - returns undefined for non-existent id
+
+  describe("create")
+    - creates challenge with draft status
+    - includes all provided fields
+    - rejects empty title (validation)
+
+  describe("update")
+    - updates specified fields
+    - does not allow setting privileged fields (user_id, submission_count)
+
+  describe("publish")
+    - sets status to active
+    - rejects publish with missing required fields (title, description)
+
+  describe("setStatus")
+    - toggles between active and inactive
+    - sets to closed
+    - rejects invalid transitions (e.g., closed -> active)
+
+  describe("deleteDraft")
+    - deletes draft challenge
+    - rejects deletion of non-draft challenges
+```
+
+### 6.2 `src/test/unit/services/challengeMediaService.test.ts`
+
+```
+describe("challengeMediaService")
+  describe("upload")
+    - uploads file to storage and creates record
+    - generates uuid-prefixed storage path
+    - returns ChallengeMedia object
+
+  describe("list")
+    - returns media ordered by sort_order
+    - returns empty array for challenge with no media
+
+  describe("getSignedUrl")
+    - returns signed URL string
+
+  describe("delete")
+    - removes storage file and database record
+
+  describe("reorder")
+    - updates sort_order for given items
+```
+
+### 6.3 `src/test/unit/services/challengeSubmissionService.test.ts`
+
+```
+describe("challengeSubmissionService")
+  describe("submit")
+    - creates submission with pending status
+    - handles duplicate submission error
+
+  describe("listForChallenge")
+    - returns submissions for a given challenge
+
+  describe("listMine")
+    - returns user's own submissions
+
+  describe("updateStatus")
+    - updates to accepted
+    - updates to rejected
+```
+
+### 6.4 `src/test/unit/components/ChallengeCard.test.tsx`
+
+```
+describe("ChallengeCard")
+  - renders title and description
+  - shows compensation badge with correct formatting (per-dataset vs lump sum)
+  - shows deadline with days remaining
+  - shows "No deadline" when null
+  - shows "Deadline passed" for past dates
+  - shows submission count
+  - renders up to 4 tags
+  - links to /marketplace/challenges/:id
+  - shows creator name
+  - shows preview media when available
+  - shows fallback icon when no media
+```
+
+### 6.5 `src/test/unit/components/ChallengeStatusBadge.test.tsx`
+
+```
+describe("ChallengeStatusBadge")
+  - renders "Draft" with gray styling for draft
+  - renders "Active" with green styling for active
+  - renders "Inactive" with yellow styling for inactive
+  - renders "Closed" with red styling for closed
+```
+
+### 6.6 `src/test/unit/components/ChallengeListCard.test.tsx`
+
+```
+describe("ChallengeListCard")
+  - renders title and status badge
+  - shows edit link to /dashboard/challenges/:id
+  - shows delete button only for draft
+  - shows publish button for draft
+  - shows deactivate button for active
+  - shows activate button for inactive
+  - hides actions for closed
+  - shows compensation and deadline info
+  - shows submission count
+```
+
+### 6.7 `src/test/integration/marketplace-challenges.test.tsx`
+
+```
+describe("MarketplacePage - Challenges Tab")
+  - renders Datasets tab by default
+  - switches to Challenges tab on click
+  - updates URL with tab parameter
+  - displays challenge cards in grid
+  - filters challenges by search query
+  - filters challenges by tag
+  - shows empty state when no challenges
+  - shows loading skeletons while fetching
+```
+
+### 6.8 `src/test/integration/dashboard-challenges.test.tsx`
+
+```
+describe("DashboardPage - Challenges Section")
+  - shows challenge count in stats
+  - renders "Create Challenge" button
+  - navigates to /dashboard/challenges/new on create click
+  - lists user's challenges with ChallengeListCard
+  - shows empty state when no challenges
+```
+
+### 6.9 `src/test/integration/challenge-detail.test.tsx`
+
+```
+describe("ChallengeDetailPage")
+  - renders challenge title and description
+  - displays media gallery
+  - shows compensation details with per-type label
+  - shows deadline countdown
+  - shows "Submit Dataset" for non-owner authenticated user
+  - hides "Submit Dataset" for unauthenticated user (shows sign-in CTA)
+  - hides "Submit Dataset" for challenge owner
+  - shows status controls for owner
+  - shows "no longer accepting" banner for inactive/closed
+  - shows submissions panel for owner
+```
+
+### 6.10 `src/test/integration/challenge-editor.test.tsx`
+
+```
+describe("ChallengeEditorPage")
+  - renders form with 4 steps
+  - can navigate between steps
+  - saves draft on button click
+  - validates required fields before publish
+  - shows pre-publish checklist
+  - publishes and redirects
+  - pre-populates form when editing existing challenge
+```
+
+---
+
+## 7. Implementation Order
+
+1. **Migration**: Supabase SQL migration with tables, constraints, triggers, indexes, RLS, storage bucket
+2. **Types**: Add Challenge, ChallengeMedia, ChallengeSubmission, EnrichedChallenge to `src/types/index.ts`
+3. **Services**: challengeService, challengeMediaService, challengeSubmissionService
+4. **Shared Components**: ChallengeStatusBadge, CompensationBadge, DeadlineCountdown
+5. **Cards**: ChallengeCard, ChallengeListCard
+6. **Upload**: ChallengeMediaUpload, ChallengeMediaGallery
+7. **Forms**: ChallengeForm (multi-step with zod)
+8. **Pages**: ChallengeEditorPage, ChallengeDetailPage
+9. **Marketplace Update**: Extract DatasetMarketplacePanel, add MarketplaceTabs, ChallengeMarketplacePanel
+10. **Dashboard Update**: Add MyChallengesSection
+11. **Routes**: Add to App.tsx
+12. **Modals**: SubmitDatasetModal
+13. **Tests**: Unit + integration tests
+14. **Polish**: Loading states, error handling, responsive design, empty states
+
+---
+
+## 8. Design Consistency
+
+All new components follow existing patterns:
+- **Cards**: `rounded-2xl border border-border/40 bg-card/50 backdrop-blur-sm`
+- **Badges**: `px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider`
+- **Icons**: Lucide React (Target for challenges, Trophy for compensation)
+- **Colors**: Primary (cyan) for actions, Secondary (purple) for accents, green/yellow/red for status
+- **Neon glow**: `shadow-[0_0_40px_hsl(var(--primary)/0.12)]` on hover
+- **Typography**: DM Sans body, JetBrains Mono for prices
+- **Layout**: `container mx-auto px-6`, `grid-cols-1 md:grid-cols-2 lg:grid-cols-3`
+- **Transitions**: `transition-all duration-300` for hover effects
+
+## 9. Security Notes
+
+- Description rendered as plain text (no rich HTML) in v1 to avoid XSS
+- Media upload: enforce `accept="video/*,image/*"` client-side + validate content_type server-side
+- File size limit: 100MB per file, 10 files per challenge (enforced client-side, storage policy server-side)
+- Storage paths use UUID prefix to prevent collisions: `{user_id}/{challenge_id}/{uuid}-{name}`
+- Signed URLs with short TTL (60s) for media access
+- Privileged fields (user_id, submission_count, published_at, closed_at) set only by DB defaults/triggers
+- RLS prevents: self-submission, submission to inactive challenges, submission with non-owned datasets
+- Status transitions enforced by DB trigger, not just client-side
+- IDOR protection: draft/inactive/closed challenges only visible to owner via RLS

--- a/prompts/creator_participant_final.md
+++ b/prompts/creator_participant_final.md
@@ -1,0 +1,80 @@
+# Creator + Participant Roles - Final Plan
+
+## Feedback Integration Note
+I attempted to request external feedback from Claude Code in the terminal, but the CLI call required network access and was blocked by permission denial in this environment. I integrated a stricter internal review pass instead, focusing on security boundaries, route stability, and minimal schema change.
+
+## Final Implementation Plan
+
+### 1) Routing and navigation cleanup
+- Keep creation/edit in editor-only routes:
+  - `/dashboard/challenges/new`
+  - `/dashboard/challenges/:id/edit`
+- Use read-only challenge detail at:
+  - `/dashboard/challenges/:id` (protected)
+  - `/marketplace/challenges/:id` (public/auth-aware)
+- Update dashboard challenge cards:
+  - title opens detail route
+  - edit button opens edit route
+
+### 2) RLS policy migration for role behavior
+Create migration to:
+- Allow submitters to submit to any active challenge, including self-created challenges.
+- Allow submitters to withdraw only pending submissions (`DELETE` policy with `status = 'pending'` and `submitter_id = auth.uid()`).
+
+### 3) Secure dataset-access expansion for submission review
+Update edge functions to preserve owner access while enabling challenge workflow:
+- `get-dataset-manifest`:
+  - owner access remains
+  - challenge owner access allowed for datasets submitted to their challenges (for review visualization)
+  - submitter access allowed
+- `dataset-read-urls`:
+  - owner access remains
+  - challenge owner access allowed only for accepted submissions (download access after acceptance)
+  - submitter access allowed
+
+This split enforces: review-before-accept via visualization, and full download after acceptance.
+
+### 4) Submission service + types enhancements
+- Add `withdraw(id)` in `challengeSubmissionService`.
+- Add enriched list methods:
+  - `listMineEnriched()` for participant dashboard grouping
+  - `listForChallengeEnriched(challengeId)` for creator moderation UX
+- Add relation-friendly types in `src/types/index.ts` for submission rows with challenge/dataset/profile metadata.
+
+### 5) Challenge detail page behavior
+- Preserve shared read-only challenge detail for creator and participant.
+- Add owner `Edit Challenge` button linking to editor route.
+- Allow authenticated users (including owner) to submit datasets when challenge is active.
+- Owner submission section:
+  - show dataset display name + submitter name + status/message/date
+  - pending: accept/reject
+  - all statuses: visualize dataset
+  - accepted: access/download file URLs
+- Add accepted file-access modal to list downloadable files.
+
+### 6) Participant dashboard submissions section
+Extend dashboard with `My Challenge Submissions`:
+- Group by challenge title.
+- For each dataset submission show status/date/message.
+- Pending -> `Withdraw` action.
+- Accepted -> show earned amount using challenge compensation and currency.
+
+### 7) Submit modal de-duplication correctness
+- Ensure submission modal receives current user’s existing submissions for the challenge, not only owner-visible list.
+- Prevent duplicate dataset re-submission to same challenge from UI side (in addition to DB unique constraint).
+
+### 8) Tests
+Update/add:
+- Unit tests for `challengeSubmissionService.withdraw` and enriched list methods.
+- Integration tests for updated routing/edit links.
+- Dashboard integration tests for participant submissions, withdraw, and accepted earnings text.
+- Data-isolation tests for withdrawal and submission policy behavior.
+
+### 9) Validation
+- Run targeted tests for changed suites first.
+- Run full test suite if time allows.
+- Manually verify:
+  - creator submits to own challenge
+  - participant withdraws pending
+  - creator visualizes pending submission
+  - creator downloads accepted submission files

--- a/prompts/creator_participant_plan.md
+++ b/prompts/creator_participant_plan.md
@@ -1,0 +1,140 @@
+# Creator + Participant Roles Implementation Plan
+
+## Objective
+Implement creator/participant role behavior for Challenges UI without introducing separate auth roles. The same authenticated user can act as creator and participant.
+
+## Scope Summary
+- Creator can view created challenges from dashboard and open non-edit detail page.
+- Creator can click `Edit` from challenge detail to modify challenge.
+- Creator can submit to own challenges.
+- Creator can view all submissions for owned challenges, open each submission dataset with existing visualization flow, and accept/reject submissions.
+- Participant can submit datasets to challenges.
+- Participant dashboard shows submissions grouped by challenge with per-submission status.
+- Participant can withdraw pending submissions.
+- Accepted submissions show earned amount for participant.
+
+## Existing Gaps Identified
+1. Dashboard challenge links route to editor (`/dashboard/challenges/:id`) instead of a read-only challenge detail page.
+2. No dashboard participant view for own challenge submissions.
+3. RLS currently blocks creator self-submission (`c.user_id != auth.uid()` in insert policy).
+4. No RLS delete policy for submitter withdrawal of pending submissions.
+5. Submission records do not expose challenge metadata in dashboard UI.
+6. Dataset visibility/download for creator reviewing submissions requires explicit accepted-submission access path (current dataset functions are owner-only).
+
+## Implementation Plan
+
+### 1) Database + RLS migrations
+Create a new migration with focused policy updates and authorization helper function:
+- Update `submissions_submitter_insert` policy to allow submissions to any active challenge, including own challenge.
+- Add `submissions_submitter_delete_pending` policy:
+  - `FOR DELETE` for authenticated users.
+  - `USING (auth.uid() = submitter_id AND status = 'pending')`.
+- Add SQL function `public.can_user_access_submission_dataset(dataset_uuid uuid)` returning boolean:
+  - true when `auth.uid()` is dataset owner.
+  - true when `auth.uid()` is challenge owner or submitter for a `challenge_submissions` row referencing the dataset.
+  - if challenge owner path is used, require submission status = `accepted` for download access; allow pending for visualization review only if required by story (we will allow read-only visualization review for challenge owner, but keep downloadable file URLs restricted to accepted submissions).
+
+Note: trigger `trg_submission_count` already handles decrement on delete, so withdrawal updates counts automatically.
+
+### 2) Edge function access updates for dataset viewing/downloading
+Update edge functions to support authorized submission access:
+- `supabase/functions/get-dataset-manifest/index.ts`
+  - Replace strict owner-only check with helper authorization:
+    - owner always allowed.
+    - challenge owner allowed when a submission exists for that dataset in their challenge.
+    - submitter allowed for own submitted dataset.
+  - Keep returning manifest used by existing visualizer (`openVisualizer`) so UI can reuse the current visualization flow.
+- `supabase/functions/dataset-read-urls/index.ts`
+  - Keep owner access.
+  - Add access for challenge owner only when there is an accepted submission for that dataset in their challenge.
+  - Add access for submitter for own dataset.
+  - This enforces “freely access/download after acceptance.”
+
+### 3) Service layer enhancements
+Update `src/services/challengeSubmissionService.ts`:
+- Add `withdraw(id: string): Promise<void>` that deletes submission row.
+- Add `listMineEnriched(): Promise<ParticipantSubmissionItem[]>` selecting:
+  - submission fields
+  - challenge fields via relation (`challenges(id,title,compensation_amount,currency,compensation_per,user_id,status)`)
+  - dataset display name via relation (`datasets(id,display_name,status)`)
+- Add helper `listForChallengeWithDatasets(challengeId: string)` to include dataset display name + submitter profile name for creator review UI.
+
+Update `src/types/index.ts`:
+- Add `ChallengeSubmissionWithRelations` and `ParticipantSubmissionItem` types for strongly typed dashboard/detail rendering.
+
+### 4) Routing and page flow changes
+Update routes in `src/App.tsx`:
+- Keep editor route at `/dashboard/challenges/new`.
+- Move edit route to `/dashboard/challenges/:id/edit`.
+- Add read-only detail route `/dashboard/challenges/:id` pointing to `ChallengeDetailPage` (protected).
+- Keep marketplace detail route `/marketplace/challenges/:id`.
+
+Update links/buttons:
+- `ChallengeListCard`:
+  - title click -> `/dashboard/challenges/:id`.
+  - edit button -> `/dashboard/challenges/:id/edit`.
+- `DashboardPage` challenge cards remain same component but now land on read-only detail.
+- `ChallengeDetailPage`:
+  - back link should route to `/dashboard` when opened from dashboard context; keep marketplace back link fallback.
+  - add owner `Edit Challenge` button to `/dashboard/challenges/:id/edit`.
+
+### 5) Creator detail-page submission review UX
+In `ChallengeDetailPage` owner section:
+- Render richer submission cards with:
+  - dataset display name and dataset id
+  - submitter name/id
+  - message + created date + status
+- Add actions:
+  - `Visualize` button (for owner) using existing `openVisualizer(sub.dataset_id)`.
+  - `Open Dataset`/`Download` button shown when submission is accepted (navigates to new accepted-access view or triggers file URL retrieval).
+  - existing `Accept` / `Reject` actions retained for pending submissions.
+- Improve accepted-state copy to indicate payout amount equals challenge compensation settings.
+
+### 6) Participant dashboard submissions UX
+Extend `DashboardPage` with a “My Challenge Submissions” section:
+- Fetch `challengeSubmissionService.listMineEnriched()` in initial load.
+- Group by challenge and render:
+  - challenge title (link to challenge detail)
+  - each submitted dataset row with status badge and submitted date
+  - if pending: `Withdraw` action
+  - if accepted: show earnings label using challenge compensation info (`formatPrice(ch.compensation_amount, ch.currency)` plus `/dataset` or `lump sum` descriptor)
+- Keep existing datasets + created challenges sections intact.
+
+### 7) Submission modal adjustments
+Update `SubmitDatasetModal` usage in `ChallengeDetailPage`:
+- Ensure `existingSubmissions` for modal dedupe uses caller’s own submissions for that challenge (not only owner list).
+- Add creator self-submission support by showing submit button to authenticated users including owner (story requirement).
+
+### 8) Test updates
+Add/update tests:
+- Unit tests for `challengeSubmissionService`:
+  - `withdraw` issues delete by id.
+  - `listMineEnriched` shape mapping.
+- Integration tests for dashboard:
+  - participant submissions section renders grouped entries.
+  - pending submission shows withdraw button.
+  - accepted submission shows earned amount text.
+- Integration test for challenge detail:
+  - owner sees edit button and submission moderation actions.
+- Data isolation tests:
+  - submitter can withdraw pending; cannot withdraw non-pending (RLS error propagation).
+  - creator self-submission path is no longer blocked at policy level.
+
+### 9) Validation checklist
+- `npm run test -- src/test/unit/auth/data-isolation.test.ts`
+- `npm run test -- src/test/integration/dashboard-challenges.test.tsx`
+- `npm run test -- src/test/integration/marketplace-challenges.test.tsx`
+- `npm run test` (full if timing permits)
+
+## Non-goals for this story
+- Real payment transfer execution and ledgering.
+- Multi-winner budget accounting for `compensation_per = challenge`.
+- Ownership transfer of dataset rows.
+
+## Risks and mitigations
+- Risk: broadening dataset access could leak files.
+  - Mitigation: keep download URLs restricted to owner and accepted-submission challenge owner only; centralize checks in edge functions.
+- Risk: route changes break existing tests/links.
+  - Mitigation: update all links + integration tests in same patch.
+- Risk: relation selects vary with generated Supabase typings.
+  - Mitigation: cast API responses to local relation types after runtime null checks.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,8 @@ const App = () => (
             <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
             <Route path="/dashboard/datasets/:id" element={<ProtectedRoute><DatasetDetailPage /></ProtectedRoute>} />
             <Route path="/dashboard/challenges/new" element={<ProtectedRoute><ChallengeEditorPage /></ProtectedRoute>} />
-            <Route path="/dashboard/challenges/:id" element={<ProtectedRoute><ChallengeEditorPage /></ProtectedRoute>} />
+            <Route path="/dashboard/challenges/:id/edit" element={<ProtectedRoute><ChallengeEditorPage /></ProtectedRoute>} />
+            <Route path="/dashboard/challenges/:id" element={<ProtectedRoute><ChallengeDetailPage /></ProtectedRoute>} />
             <Route path="/keys" element={<ProtectedRoute><KeysPage /></ProtectedRoute>} />
             <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
             <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,8 @@ import DatasetDetailPage from "@/pages/DatasetDetailPage";
 import ProfilePage from "@/pages/ProfilePage";
 import SearchPage from "@/pages/SearchPage";
 import ListingPage from "@/pages/ListingPage";
+import ChallengeEditorPage from "@/pages/ChallengeEditorPage";
+import ChallengeDetailPage from "@/pages/ChallengeDetailPage";
 import NotFound from "@/pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -44,6 +46,8 @@ const App = () => (
             <Route path="/reset-password" element={<ResetPasswordPage />} />
             <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
             <Route path="/dashboard/datasets/:id" element={<ProtectedRoute><DatasetDetailPage /></ProtectedRoute>} />
+            <Route path="/dashboard/challenges/new" element={<ProtectedRoute><ChallengeEditorPage /></ProtectedRoute>} />
+            <Route path="/dashboard/challenges/:id" element={<ProtectedRoute><ChallengeEditorPage /></ProtectedRoute>} />
             <Route path="/keys" element={<ProtectedRoute><KeysPage /></ProtectedRoute>} />
             <Route path="/settings" element={<ProtectedRoute><SettingsPage /></ProtectedRoute>} />
             <Route path="/profile" element={<ProtectedRoute><ProfilePage /></ProtectedRoute>} />
@@ -51,6 +55,7 @@ const App = () => (
             <Route path="/sessions/:id/viewer" element={<ProtectedRoute><SessionViewerPage /></ProtectedRoute>} />
             <Route path="/search" element={<ProtectedRoute><SearchPage /></ProtectedRoute>} />
             <Route path="/marketplace" element={<MarketplacePage />} />
+            <Route path="/marketplace/challenges/:id" element={<ChallengeDetailPage />} />
             <Route path="/marketplace/:id" element={<ListingPage />} />
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/ChallengeCard.tsx
+++ b/src/components/ChallengeCard.tsx
@@ -1,0 +1,119 @@
+import { Link } from "react-router-dom";
+import { formatPrice } from "@/lib/marketplace";
+import type { EnrichedChallenge } from "@/types";
+import {
+  Target, Trophy, User, ArrowRight, Calendar, Clock,
+  Tag, MessageSquare, Film,
+} from "lucide-react";
+
+function deadlineLabel(deadline: string | null): { text: string; urgent: boolean } {
+  if (!deadline) return { text: "No deadline", urgent: false };
+  const now = new Date();
+  const dl = new Date(deadline);
+  const diffMs = dl.getTime() - now.getTime();
+  if (diffMs < 0) return { text: "Deadline passed", urgent: true };
+  const days = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  if (days <= 3) return { text: `${days}d left`, urgent: true };
+  return { text: `${days}d left`, urgent: false };
+}
+
+const ChallengeCard = ({ challenge }: { challenge: EnrichedChallenge }) => {
+  const { text: deadlineText, urgent } = deadlineLabel(challenge.deadline);
+  const isLumpSum = challenge.compensation_per === "challenge";
+
+  return (
+    <Link to={`/marketplace/challenges/${challenge.id}`} className="group block" data-testid="challenge-card">
+      <div className="relative rounded-2xl border border-border/40 bg-card/50 backdrop-blur-sm overflow-hidden transition-all duration-500 hover:border-secondary/40 hover:shadow-[0_0_40px_hsl(var(--secondary)/0.12)] hover:-translate-y-1">
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,hsl(var(--primary)/0.06),transparent_70%)] opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+
+        {/* Thumbnail */}
+        <div className="relative h-44 overflow-hidden bg-muted/20 flex items-center justify-center">
+          {challenge.preview_url ? (
+            challenge.preview_url.match(/\.(mp4|webm|avi)/) ? (
+              <video
+                src={challenge.preview_url}
+                muted
+                preload="metadata"
+                className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+                onLoadedData={(e) => { e.currentTarget.currentTime = 0.1; }}
+              />
+            ) : (
+              <img
+                src={challenge.preview_url}
+                alt={challenge.title}
+                className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+              />
+            )
+          ) : (
+            <Target className="h-10 w-10 text-muted-foreground/30" />
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-card via-card/40 to-transparent" />
+
+          {/* Challenge badge */}
+          <div className="absolute top-3 left-3">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[9px] font-semibold bg-secondary/20 text-secondary border border-secondary/30 backdrop-blur-sm">
+              <Target className="h-2.5 w-2.5" /> Challenge
+            </span>
+          </div>
+
+          {/* Compensation badge */}
+          <div className="absolute top-3 right-3">
+            {challenge.compensation_amount === 0 ? (
+              <span className="px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider bg-primary/20 text-primary border border-primary/30 backdrop-blur-sm shadow-[0_0_12px_hsl(var(--primary)/0.3)]">
+                Volunteer
+              </span>
+            ) : (
+              <span className={`px-3 py-1 rounded-full text-[10px] font-bold tracking-wider backdrop-blur-sm shadow-[0_0_12px_hsl(var(--secondary)/0.3)] ${
+                isLumpSum
+                  ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
+                  : "bg-green-500/20 text-green-400 border border-green-500/30"
+              }`}>
+                {formatPrice(challenge.compensation_amount, challenge.currency)}
+                <span className="text-[8px] ml-1 opacity-70">
+                  {isLumpSum ? "total" : "/dataset"}
+                </span>
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="relative p-5">
+          <h3 className="text-sm font-semibold text-foreground mb-1.5 group-hover:text-secondary transition-colors">
+            {challenge.title}
+          </h3>
+          <p className="text-[11px] text-muted-foreground leading-relaxed line-clamp-2 mb-3">
+            {challenge.description}
+          </p>
+
+          {/* Tags */}
+          <div className="flex flex-wrap gap-1.5 mb-3">
+            {challenge.tags.slice(0, 4).map((tag) => (
+              <span key={tag} className="px-2 py-0.5 rounded-full text-[9px] font-medium bg-muted/40 text-muted-foreground border border-border/30">
+                {tag}
+              </span>
+            ))}
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between pt-3 border-t border-border/20">
+            <div className="flex items-center gap-4 text-[10px] text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <User className="h-3 w-3" /> {challenge.creator_name}
+              </span>
+              <span className={`flex items-center gap-1 ${urgent ? "text-red-400" : ""}`}>
+                <Clock className="h-3 w-3" /> {deadlineText}
+              </span>
+              <span className="flex items-center gap-1">
+                <MessageSquare className="h-3 w-3" /> {challenge.submission_count}
+              </span>
+            </div>
+            <ArrowRight className="h-3.5 w-3.5 text-muted-foreground group-hover:text-secondary group-hover:translate-x-0.5 transition-all" />
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default ChallengeCard;

--- a/src/components/ChallengeListCard.tsx
+++ b/src/components/ChallengeListCard.tsx
@@ -108,7 +108,7 @@ const ChallengeListCard = ({
         )}
         {challenge.status !== "closed" && (
           <>
-            <Link to={`/dashboard/challenges/${challenge.id}`}>
+            <Link to={`/dashboard/challenges/${challenge.id}/edit`}>
               <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-xs" data-testid="edit-btn">
                 <Pencil className="h-3.5 w-3.5" /> Edit
               </Button>

--- a/src/components/ChallengeListCard.tsx
+++ b/src/components/ChallengeListCard.tsx
@@ -1,0 +1,132 @@
+import { Link } from "react-router-dom";
+import { formatPrice } from "@/lib/marketplace";
+import ChallengeStatusBadge from "@/components/ChallengeStatusBadge";
+import type { Challenge } from "@/types";
+import { Button } from "@/components/ui/button";
+import {
+  Target, Pencil, Trash2, Send, ToggleLeft, ToggleRight, XCircle, Clock, MessageSquare,
+} from "lucide-react";
+
+interface ChallengeListCardProps {
+  challenge: Challenge;
+  onPublish?: (id: string) => void;
+  onToggleStatus?: (id: string, status: "active" | "inactive") => void;
+  onClose?: (id: string) => void;
+  onDelete?: (id: string) => void;
+}
+
+const ChallengeListCard = ({
+  challenge,
+  onPublish,
+  onToggleStatus,
+  onClose,
+  onDelete,
+}: ChallengeListCardProps) => {
+  const deadlineText = challenge.deadline
+    ? new Date(challenge.deadline).toLocaleDateString()
+    : "No deadline";
+
+  return (
+    <div
+      className="flex items-center justify-between rounded-2xl border border-border/40 bg-card/50 backdrop-blur-sm p-4 transition-all duration-300 hover:border-secondary/30"
+      data-testid="challenge-list-card"
+    >
+      <div className="flex items-center gap-4 min-w-0 flex-1">
+        <div className="h-10 w-10 rounded-xl bg-secondary/10 flex items-center justify-center shrink-0">
+          <Target className="h-5 w-5 text-secondary" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <Link
+              to={`/dashboard/challenges/${challenge.id}`}
+              className="text-sm font-semibold text-foreground hover:text-secondary transition-colors truncate"
+            >
+              {challenge.title}
+            </Link>
+            <ChallengeStatusBadge status={challenge.status} />
+          </div>
+          <div className="flex items-center gap-4 text-[10px] text-muted-foreground">
+            <span>
+              {challenge.compensation_amount === 0
+                ? "Volunteer"
+                : `${formatPrice(challenge.compensation_amount, challenge.currency)} ${challenge.compensation_per === "challenge" ? "total" : "/dataset"}`}
+            </span>
+            <span className="flex items-center gap-1">
+              <Clock className="h-3 w-3" /> {deadlineText}
+            </span>
+            <span className="flex items-center gap-1">
+              <MessageSquare className="h-3 w-3" /> {challenge.submission_count} submissions
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1.5 shrink-0 ml-4">
+        {challenge.status === "draft" && (
+          <>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 text-xs"
+              onClick={() => onPublish?.(challenge.id)}
+              data-testid="publish-btn"
+            >
+              <Send className="h-3.5 w-3.5" /> Publish
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 text-xs text-destructive hover:text-destructive"
+              onClick={() => onDelete?.(challenge.id)}
+              data-testid="delete-btn"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </>
+        )}
+        {challenge.status === "active" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={() => onToggleStatus?.(challenge.id, "inactive")}
+            data-testid="deactivate-btn"
+          >
+            <ToggleLeft className="h-3.5 w-3.5" /> Deactivate
+          </Button>
+        )}
+        {challenge.status === "inactive" && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={() => onToggleStatus?.(challenge.id, "active")}
+            data-testid="activate-btn"
+          >
+            <ToggleRight className="h-3.5 w-3.5" /> Activate
+          </Button>
+        )}
+        {challenge.status !== "closed" && (
+          <>
+            <Link to={`/dashboard/challenges/${challenge.id}`}>
+              <Button variant="ghost" size="sm" className="h-8 gap-1.5 text-xs" data-testid="edit-btn">
+                <Pencil className="h-3.5 w-3.5" /> Edit
+              </Button>
+            </Link>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 text-xs text-destructive hover:text-destructive"
+              onClick={() => onClose?.(challenge.id)}
+              data-testid="close-btn"
+            >
+              <XCircle className="h-3.5 w-3.5" /> Close
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ChallengeListCard;

--- a/src/components/ChallengeMediaUpload.tsx
+++ b/src/components/ChallengeMediaUpload.tsx
@@ -1,0 +1,143 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { Upload, X, Film, Image as ImageIcon, GripVertical } from "lucide-react";
+import { challengeMediaService } from "@/services/challengeMediaService";
+import type { ChallengeMedia } from "@/types";
+
+interface ChallengeMediaUploadProps {
+  challengeId: string;
+  userId: string;
+  onMediaChange?: (media: ChallengeMedia[]) => void;
+}
+
+const MAX_FILES = 10;
+const MAX_SIZE_BYTES = 100 * 1024 * 1024; // 100MB
+
+const ChallengeMediaUpload = ({ challengeId, userId, onMediaChange }: ChallengeMediaUploadProps) => {
+  const [media, setMedia] = useState<ChallengeMedia[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [signedUrls, setSignedUrls] = useState<Map<string, string>>(new Map());
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    challengeMediaService.list(challengeId).then((items) => {
+      setMedia(items);
+      onMediaChange?.(items);
+      items.forEach((item) => {
+        challengeMediaService.getSignedUrl(item.storage_path).then((url) => {
+          setSignedUrls((prev) => new Map(prev).set(item.id, url));
+        });
+      });
+    });
+  }, [challengeId]);
+
+  const handleFiles = useCallback(async (files: FileList | null) => {
+    if (!files || uploading) return;
+    const toUpload = Array.from(files).filter((f) => {
+      if (f.size > MAX_SIZE_BYTES) return false;
+      if (!f.type.startsWith("video/") && !f.type.startsWith("image/")) return false;
+      return true;
+    });
+    if (media.length + toUpload.length > MAX_FILES) return;
+
+    setUploading(true);
+    try {
+      const newMedia: ChallengeMedia[] = [];
+      for (const file of toUpload) {
+        const m = await challengeMediaService.upload(challengeId, userId, file);
+        newMedia.push(m);
+        const url = await challengeMediaService.getSignedUrl(m.storage_path);
+        setSignedUrls((prev) => new Map(prev).set(m.id, url));
+      }
+      const updated = [...media, ...newMedia];
+      setMedia(updated);
+      onMediaChange?.(updated);
+    } finally {
+      setUploading(false);
+    }
+  }, [challengeId, userId, media, uploading, onMediaChange]);
+
+  const handleDelete = async (item: ChallengeMedia) => {
+    await challengeMediaService.delete(item.id, item.storage_path);
+    const updated = media.filter((m) => m.id !== item.id);
+    setMedia(updated);
+    onMediaChange?.(updated);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Upload zone */}
+      <div
+        onClick={() => fileInputRef.current?.click()}
+        onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+        onDragLeave={(e) => { e.preventDefault(); setIsDragging(false); }}
+        onDrop={(e) => { e.preventDefault(); setIsDragging(false); handleFiles(e.dataTransfer.files); }}
+        className={`relative rounded-xl border-2 border-dashed cursor-pointer transition-all duration-300 ${
+          isDragging
+            ? "border-secondary bg-secondary/5"
+            : "border-border/40 bg-background/20 hover:border-secondary/30"
+        } ${media.length >= MAX_FILES ? "opacity-50 pointer-events-none" : ""}`}
+      >
+        <div className="flex flex-col items-center justify-center py-8 px-4">
+          <Upload className={`h-5 w-5 mb-2 ${isDragging ? "text-secondary" : "text-muted-foreground"}`} />
+          <p className="text-xs text-foreground font-medium mb-1">
+            {uploading ? "Uploading..." : isDragging ? "Drop files here" : "Drag & drop videos or images"}
+          </p>
+          <p className="text-[10px] text-muted-foreground">
+            Max {MAX_FILES} files, 100MB each
+          </p>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept="video/*,image/*"
+          className="hidden"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+      </div>
+
+      {/* Media preview grid */}
+      {media.length > 0 && (
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          {media.map((item) => {
+            const url = signedUrls.get(item.id);
+            const isVideo = item.content_type.startsWith("video/");
+            return (
+              <div
+                key={item.id}
+                className="relative rounded-xl border border-border/30 bg-card/40 overflow-hidden group"
+              >
+                <div className="aspect-video flex items-center justify-center bg-muted/20">
+                  {url ? (
+                    isVideo ? (
+                      <video src={url} muted preload="metadata" className="w-full h-full object-cover"
+                        onLoadedData={(e) => { e.currentTarget.currentTime = 0.1; }} />
+                    ) : (
+                      <img src={url} alt={item.file_name} className="w-full h-full object-cover" />
+                    )
+                  ) : (
+                    isVideo ? <Film className="h-6 w-6 text-muted-foreground/30" /> : <ImageIcon className="h-6 w-6 text-muted-foreground/30" />
+                  )}
+                </div>
+                <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <button
+                    onClick={(e) => { e.stopPropagation(); handleDelete(item); }}
+                    className="h-6 w-6 rounded-full bg-card/80 backdrop-blur-sm border border-border/40 flex items-center justify-center hover:bg-destructive/20 transition-colors"
+                  >
+                    <X className="h-3 w-3 text-foreground" />
+                  </button>
+                </div>
+                <p className="text-[9px] text-muted-foreground truncate px-2 py-1">
+                  {item.file_name}
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChallengeMediaUpload;

--- a/src/components/ChallengeStatusBadge.tsx
+++ b/src/components/ChallengeStatusBadge.tsx
@@ -1,0 +1,22 @@
+import type { Challenge } from "@/types";
+
+const STATUS_STYLES: Record<Challenge["status"], { label: string; classes: string }> = {
+  draft: { label: "Draft", classes: "border-muted-foreground/30 bg-muted/20 text-muted-foreground" },
+  active: { label: "Active", classes: "border-green-500/30 bg-green-500/10 text-green-400" },
+  inactive: { label: "Inactive", classes: "border-yellow-500/30 bg-yellow-500/10 text-yellow-400" },
+  closed: { label: "Closed", classes: "border-red-500/30 bg-red-500/10 text-red-400" },
+};
+
+const ChallengeStatusBadge = ({ status }: { status: Challenge["status"] }) => {
+  const { label, classes } = STATUS_STYLES[status];
+  return (
+    <span
+      className={`px-2 py-0.5 rounded-full text-[9px] font-bold uppercase tracking-wider border ${classes}`}
+      data-testid="challenge-status-badge"
+    >
+      {label}
+    </span>
+  );
+};
+
+export default ChallengeStatusBadge;

--- a/src/components/SubmitDatasetModal.tsx
+++ b/src/components/SubmitDatasetModal.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect } from "react";
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { Send, Loader2 } from "lucide-react";
+import { listDatasets } from "@/services/datasetService";
+import { challengeSubmissionService } from "@/services/challengeSubmissionService";
+import type { ChallengeSubmission } from "@/types";
+import { toast } from "sonner";
+
+interface SubmitDatasetModalProps {
+  open: boolean;
+  onClose: () => void;
+  challengeId: string;
+  existingSubmissions: ChallengeSubmission[];
+  onSubmitted: () => void;
+}
+
+const SubmitDatasetModal = ({
+  open, onClose, challengeId, existingSubmissions, onSubmitted,
+}: SubmitDatasetModalProps) => {
+  const [datasets, setDatasets] = useState<{ id: string; display_name: string }[]>([]);
+  const [selectedDatasetId, setSelectedDatasetId] = useState("");
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    listDatasets().then((all) => {
+      const alreadySubmittedIds = new Set(existingSubmissions.map((s) => s.dataset_id));
+      const eligible = all
+        .filter((d: any) => d.status === "ready" && !alreadySubmittedIds.has(d.id));
+      setDatasets(eligible.map((d: any) => ({ id: d.id, display_name: d.display_name })));
+      setLoading(false);
+    });
+  }, [open, existingSubmissions]);
+
+  const handleSubmit = async () => {
+    if (!selectedDatasetId) return;
+    setSubmitting(true);
+    try {
+      await challengeSubmissionService.submit({
+        challenge_id: challengeId,
+        dataset_id: selectedDatasetId,
+        message: message.trim(),
+      });
+      toast.success("Dataset submitted to challenge!");
+      onSubmitted();
+      onClose();
+      setSelectedDatasetId("");
+      setMessage("");
+    } catch (err: any) {
+      toast.error(err.message || "Failed to submit");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md border-border/50 bg-card/95 backdrop-blur-xl">
+        <DialogHeader>
+          <DialogTitle className="text-foreground flex items-center gap-2">
+            <Send className="h-5 w-5 text-secondary" />
+            Submit Dataset
+          </DialogTitle>
+          <DialogDescription className="text-muted-foreground">
+            Propose one of your datasets as a solution to this challenge.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 mt-2">
+          <div className="space-y-1.5">
+            <Label className="text-xs">Select Dataset</Label>
+            {loading ? (
+              <div className="h-10 rounded-xl bg-muted/20 animate-pulse" />
+            ) : datasets.length === 0 ? (
+              <p className="text-[11px] text-muted-foreground bg-muted/20 rounded-xl p-3">
+                No eligible datasets. You need a dataset with "ready" status that hasn't already been submitted to this challenge.
+              </p>
+            ) : (
+              <Select value={selectedDatasetId} onValueChange={setSelectedDatasetId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose a dataset..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {datasets.map((d) => (
+                    <SelectItem key={d.id} value={d.id}>{d.display_name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="submit-msg" className="text-xs">Message (optional)</Label>
+            <Textarea
+              id="submit-msg"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="Explain how your dataset meets the challenge requirements..."
+              rows={3}
+            />
+          </div>
+
+          <Button
+            variant="neon"
+            className="w-full gap-2"
+            onClick={handleSubmit}
+            disabled={submitting || !selectedDatasetId}
+          >
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+            {submitting ? "Submitting..." : "Submit Dataset"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SubmitDatasetModal;

--- a/src/pages/ChallengeDetailPage.tsx
+++ b/src/pages/ChallengeDetailPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useLocation } from "react-router-dom";
 import { formatPrice } from "@/lib/marketplace";
 import { challengeService } from "@/services/challengeService";
 import { challengeMediaService } from "@/services/challengeMediaService";
 import { challengeSubmissionService } from "@/services/challengeSubmissionService";
+import { getDatasetFileUrls, type SignedFileUrl } from "@/services/datasetService";
+import { openVisualizer } from "@/lib/visualizer";
 import { useAuth } from "@/hooks/useAuth";
 import SubmitDatasetModal from "@/components/SubmitDatasetModal";
 import ChallengeStatusBadge from "@/components/ChallengeStatusBadge";
@@ -14,29 +16,44 @@ import {
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import type { Challenge, ChallengeMedia, ChallengeSubmission } from "@/types";
+import {
+  Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import type {
+  Challenge,
+  ChallengeMedia,
+  ChallengeSubmission,
+  ChallengeSubmissionEnriched,
+} from "@/types";
 import { toast } from "sonner";
 import {
   Target, Trophy, Clock, User, Tag, Send, ToggleLeft, ToggleRight,
   XCircle, ArrowLeft, Film, Image as ImageIcon, CheckCircle2, XIcon,
-  MessageSquare, Calendar, AlertTriangle,
+  MessageSquare, Calendar, AlertTriangle, Pencil, Eye, Download,
 } from "lucide-react";
 
 const ChallengeDetailPage = () => {
   const { id } = useParams<{ id: string }>();
+  const location = useLocation();
   const { isAuthenticated, user } = useAuth();
 
   const [challenge, setChallenge] = useState<Challenge | null>(null);
   const [media, setMedia] = useState<ChallengeMedia[]>([]);
   const [mediaUrls, setMediaUrls] = useState<Map<string, string>>(new Map());
-  const [submissions, setSubmissions] = useState<ChallengeSubmission[]>([]);
+  const [ownerSubmissions, setOwnerSubmissions] = useState<ChallengeSubmissionEnriched[]>([]);
+  const [mySubmissions, setMySubmissions] = useState<ChallengeSubmission[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitOpen, setSubmitOpen] = useState(false);
   const [activeMedia, setActiveMedia] = useState<string | null>(null);
+  const [filesOpen, setFilesOpen] = useState(false);
+  const [filesLoading, setFilesLoading] = useState(false);
+  const [selectedSubmissionName, setSelectedSubmissionName] = useState<string>("");
+  const [submissionFiles, setSubmissionFiles] = useState<SignedFileUrl[]>([]);
 
-  const isOwner = user && challenge && user.id === challenge.user_id;
+  const isOwner = !!(user && challenge && user.id === challenge.user_id);
   const isActive = challenge?.status === "active";
   const isClosed = challenge?.status === "closed" || challenge?.status === "inactive";
+  const backTo = location.pathname.startsWith("/dashboard") ? "/dashboard" : "/marketplace?tab=challenges";
 
   useEffect(() => {
     if (!id) return;
@@ -57,12 +74,43 @@ const ChallengeDetailPage = () => {
   }, [id]);
 
   useEffect(() => {
-    if (!id || !isOwner) return;
-    challengeSubmissionService.listForChallenge(id).then(setSubmissions);
-  }, [id, isOwner]);
+    if (!id) return;
+
+    if (isAuthenticated) {
+      challengeSubmissionService
+        .listMine()
+        .then((rows) => setMySubmissions(rows.filter((row) => row.challenge_id === id)))
+        .catch(() => setMySubmissions([]));
+    } else {
+      setMySubmissions([]);
+    }
+
+    if (!isOwner) {
+      setOwnerSubmissions([]);
+      return;
+    }
+    challengeSubmissionService
+      .listForChallengeEnriched(id)
+      .then(setOwnerSubmissions)
+      .catch(() => setOwnerSubmissions([]));
+  }, [id, isOwner, isAuthenticated]);
 
   const refreshSubmissions = () => {
-    if (id) challengeSubmissionService.listForChallenge(id).then(setSubmissions);
+    if (!id) return;
+
+    if (isAuthenticated) {
+      challengeSubmissionService
+        .listMine()
+        .then((rows) => setMySubmissions(rows.filter((row) => row.challenge_id === id)))
+        .catch(() => setMySubmissions([]));
+    }
+
+    if (isOwner) {
+      challengeSubmissionService
+        .listForChallengeEnriched(id)
+        .then(setOwnerSubmissions)
+        .catch(() => setOwnerSubmissions([]));
+    }
   };
 
   const handleToggleStatus = async (status: "active" | "inactive") => {
@@ -97,6 +145,29 @@ const ChallengeDetailPage = () => {
     }
   };
 
+  const handleVisualizeSubmission = async (datasetId: string) => {
+    try {
+      await openVisualizer(datasetId);
+    } catch (err: any) {
+      toast.error(err.message || "Failed to open visualizer");
+    }
+  };
+
+  const handleOpenAcceptedFiles = async (datasetId: string, datasetName: string | null) => {
+    setFilesOpen(true);
+    setFilesLoading(true);
+    setSelectedSubmissionName(datasetName || datasetId);
+    setSubmissionFiles([]);
+    try {
+      const urls = await getDatasetFileUrls(datasetId);
+      setSubmissionFiles(urls.filter((u) => !!u.signed_url));
+    } catch (err: any) {
+      toast.error(err.message || "Failed to load downloadable files");
+    } finally {
+      setFilesLoading(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen pt-16 bg-background">
@@ -114,8 +185,8 @@ const ChallengeDetailPage = () => {
         <div className="text-center">
           <Target className="h-12 w-12 text-muted-foreground/30 mx-auto mb-4" />
           <p className="text-muted-foreground">Challenge not found.</p>
-          <Link to="/marketplace?tab=challenges" className="text-primary text-sm hover:underline mt-2 inline-block">
-            Back to Marketplace
+          <Link to={backTo} className="text-primary text-sm hover:underline mt-2 inline-block">
+            Back
           </Link>
         </div>
       </div>
@@ -133,8 +204,8 @@ const ChallengeDetailPage = () => {
     <div className="min-h-screen pt-16 bg-background">
       <div className="container mx-auto px-6 pt-8 pb-20">
         {/* Back link */}
-        <Link to="/marketplace?tab=challenges" className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6">
-          <ArrowLeft className="h-4 w-4" /> Back to Challenges
+        <Link to={backTo} className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="h-4 w-4" /> {location.pathname.startsWith("/dashboard") ? "Back to Dashboard" : "Back to Challenges"}
         </Link>
 
         {/* Status banner */}
@@ -262,16 +333,24 @@ const ChallengeDetailPage = () => {
             )}
 
             {/* Owner: Submissions */}
-            {isOwner && submissions.length > 0 && (
+            {isOwner && ownerSubmissions.length > 0 && (
               <GlassCard hover={false}>
                 <h2 className="text-sm font-semibold text-foreground mb-4">
-                  Submissions ({submissions.length})
+                  Submissions ({ownerSubmissions.length})
                 </h2>
                 <div className="space-y-3">
-                  {submissions.map((sub) => (
-                    <div key={sub.id} className="flex items-center justify-between rounded-xl border border-border/30 bg-background/30 p-3">
+                  {ownerSubmissions.map((sub) => (
+                    <div key={sub.id} className="rounded-xl border border-border/30 bg-background/30 p-3">
                       <div className="min-w-0 flex-1">
-                        <p className="text-xs font-mono text-foreground truncate">{sub.dataset_id}</p>
+                        <p className="text-xs font-medium text-foreground truncate">
+                          {sub.dataset_display_name || sub.dataset_id}
+                        </p>
+                        <p className="text-[10px] text-muted-foreground mt-1">
+                          Dataset ID: <span className="font-mono">{sub.dataset_id}</span>
+                        </p>
+                        <p className="text-[10px] text-muted-foreground mt-1">
+                          Submitter: {sub.submitter_name || sub.submitter_id}
+                        </p>
                         {sub.message && (
                           <p className="text-[11px] text-muted-foreground mt-1 line-clamp-2">{sub.message}</p>
                         )}
@@ -284,9 +363,34 @@ const ChallengeDetailPage = () => {
                             {sub.status}
                           </span>
                         </p>
+                        {sub.status === "accepted" && (
+                          <p className="text-[10px] text-green-400 mt-1">
+                            Accepted payout: {formatPrice(challenge.compensation_amount, challenge.currency)}{" "}
+                            {challenge.compensation_per === "challenge" ? "(lump sum)" : "per dataset"}
+                          </p>
+                        )}
                       </div>
-                      {sub.status === "pending" && (
-                        <div className="flex items-center gap-1.5 ml-3 shrink-0">
+                      <div className="flex items-center gap-1.5 mt-3">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1 text-[10px]"
+                          onClick={() => handleVisualizeSubmission(sub.dataset_id)}
+                        >
+                          <Eye className="h-3 w-3" /> Visualize
+                        </Button>
+                        {sub.status === "accepted" && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 gap-1 text-[10px]"
+                            onClick={() => handleOpenAcceptedFiles(sub.dataset_id, sub.dataset_display_name)}
+                          >
+                            <Download className="h-3 w-3" /> Access Files
+                          </Button>
+                        )}
+                        {sub.status === "pending" && (
+                          <>
                           <Button
                             variant="ghost"
                             size="sm"
@@ -303,8 +407,9 @@ const ChallengeDetailPage = () => {
                           >
                             <XIcon className="h-3 w-3" /> Reject
                           </Button>
-                        </div>
-                      )}
+                          </>
+                        )}
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -355,7 +460,7 @@ const ChallengeDetailPage = () => {
             </GlassCard>
 
             {/* Submit button */}
-            {isAuthenticated && !isOwner && isActive && (
+            {isAuthenticated && isActive && (
               <Button
                 variant="neon"
                 className="w-full gap-2"
@@ -378,6 +483,15 @@ const ChallengeDetailPage = () => {
               <GlassCard hover={false}>
                 <p className="text-xs font-semibold text-foreground mb-3">Manage Challenge</p>
                 <div className="space-y-2">
+                  <Link to={`/dashboard/challenges/${challenge.id}/edit`} className="block">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="w-full justify-start gap-2 text-xs"
+                    >
+                      <Pencil className="h-3.5 w-3.5" /> Edit Challenge
+                    </Button>
+                  </Link>
                   {challenge.status === "active" && (
                     <Button
                       variant="ghost"
@@ -433,9 +547,39 @@ const ChallengeDetailPage = () => {
         open={submitOpen}
         onClose={() => setSubmitOpen(false)}
         challengeId={challenge.id}
-        existingSubmissions={submissions}
+        existingSubmissions={mySubmissions}
         onSubmitted={refreshSubmissions}
       />
+
+      <Dialog open={filesOpen} onOpenChange={setFilesOpen}>
+        <DialogContent className="sm:max-w-lg border-border/50 bg-card/95 backdrop-blur-xl">
+          <DialogHeader>
+            <DialogTitle className="text-foreground">Accepted Submission Files</DialogTitle>
+            <DialogDescription className="text-muted-foreground">
+              {selectedSubmissionName}
+            </DialogDescription>
+          </DialogHeader>
+          {filesLoading ? (
+            <div className="h-24 rounded-xl bg-muted/20 animate-pulse" />
+          ) : submissionFiles.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No downloadable files available.</p>
+          ) : (
+            <div className="space-y-2 max-h-80 overflow-y-auto">
+              {submissionFiles.map((file) => (
+                <div
+                  key={file.relative_path}
+                  className="flex items-center justify-between gap-3 rounded-xl border border-border/30 bg-background/30 p-2.5"
+                >
+                  <span className="text-[11px] font-mono text-foreground truncate">{file.relative_path}</span>
+                  <a href={file.signed_url ?? "#"} target="_blank" rel="noopener noreferrer">
+                    <Button variant="ghost" size="sm" className="h-7 text-[10px]">Download</Button>
+                  </a>
+                </div>
+              ))}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/src/pages/ChallengeDetailPage.tsx
+++ b/src/pages/ChallengeDetailPage.tsx
@@ -1,0 +1,443 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { formatPrice } from "@/lib/marketplace";
+import { challengeService } from "@/services/challengeService";
+import { challengeMediaService } from "@/services/challengeMediaService";
+import { challengeSubmissionService } from "@/services/challengeSubmissionService";
+import { useAuth } from "@/hooks/useAuth";
+import SubmitDatasetModal from "@/components/SubmitDatasetModal";
+import ChallengeStatusBadge from "@/components/ChallengeStatusBadge";
+import GlassCard from "@/components/GlassCard";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import type { Challenge, ChallengeMedia, ChallengeSubmission } from "@/types";
+import { toast } from "sonner";
+import {
+  Target, Trophy, Clock, User, Tag, Send, ToggleLeft, ToggleRight,
+  XCircle, ArrowLeft, Film, Image as ImageIcon, CheckCircle2, XIcon,
+  MessageSquare, Calendar, AlertTriangle,
+} from "lucide-react";
+
+const ChallengeDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const { isAuthenticated, user } = useAuth();
+
+  const [challenge, setChallenge] = useState<Challenge | null>(null);
+  const [media, setMedia] = useState<ChallengeMedia[]>([]);
+  const [mediaUrls, setMediaUrls] = useState<Map<string, string>>(new Map());
+  const [submissions, setSubmissions] = useState<ChallengeSubmission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitOpen, setSubmitOpen] = useState(false);
+  const [activeMedia, setActiveMedia] = useState<string | null>(null);
+
+  const isOwner = user && challenge && user.id === challenge.user_id;
+  const isActive = challenge?.status === "active";
+  const isClosed = challenge?.status === "closed" || challenge?.status === "inactive";
+
+  useEffect(() => {
+    if (!id) return;
+    Promise.all([
+      challengeService.get(id),
+      challengeMediaService.list(id),
+    ]).then(([ch, med]) => {
+      setChallenge(ch ?? null);
+      setMedia(med);
+      if (med.length > 0) setActiveMedia(med[0].id);
+      med.forEach((m) => {
+        challengeMediaService.getSignedUrl(m.storage_path).then((url) => {
+          setMediaUrls((prev) => new Map(prev).set(m.id, url));
+        });
+      });
+      setLoading(false);
+    });
+  }, [id]);
+
+  useEffect(() => {
+    if (!id || !isOwner) return;
+    challengeSubmissionService.listForChallenge(id).then(setSubmissions);
+  }, [id, isOwner]);
+
+  const refreshSubmissions = () => {
+    if (id) challengeSubmissionService.listForChallenge(id).then(setSubmissions);
+  };
+
+  const handleToggleStatus = async (status: "active" | "inactive") => {
+    if (!challenge) return;
+    try {
+      const updated = await challengeService.setStatus(challenge.id, status);
+      setChallenge(updated);
+      toast.success(`Challenge ${status === "active" ? "activated" : "deactivated"}`);
+    } catch (err: any) {
+      toast.error(err.message || "Failed to update status");
+    }
+  };
+
+  const handleClose = async () => {
+    if (!challenge) return;
+    try {
+      const updated = await challengeService.setStatus(challenge.id, "closed");
+      setChallenge(updated);
+      toast.success("Challenge closed permanently");
+    } catch (err: any) {
+      toast.error(err.message || "Failed to close");
+    }
+  };
+
+  const handleSubmissionAction = async (subId: string, status: "accepted" | "rejected") => {
+    try {
+      await challengeSubmissionService.updateStatus(subId, status);
+      refreshSubmissions();
+      toast.success(`Submission ${status}`);
+    } catch (err: any) {
+      toast.error(err.message || "Failed to update");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen pt-16 bg-background">
+        <div className="container mx-auto px-6 pt-16">
+          <div className="h-8 w-48 rounded-xl bg-muted/20 animate-pulse mb-6" />
+          <div className="h-96 rounded-2xl bg-muted/20 animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!challenge) {
+    return (
+      <div className="min-h-screen pt-16 bg-background flex items-center justify-center">
+        <div className="text-center">
+          <Target className="h-12 w-12 text-muted-foreground/30 mx-auto mb-4" />
+          <p className="text-muted-foreground">Challenge not found.</p>
+          <Link to="/marketplace?tab=challenges" className="text-primary text-sm hover:underline mt-2 inline-block">
+            Back to Marketplace
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const deadlineDate = challenge.deadline ? new Date(challenge.deadline) : null;
+  const deadlinePassed = deadlineDate ? deadlineDate.getTime() < Date.now() : false;
+  const isLumpSum = challenge.compensation_per === "challenge";
+
+  const activeMediaItem = media.find((m) => m.id === activeMedia);
+  const activeMediaUrl = activeMedia ? mediaUrls.get(activeMedia) : null;
+
+  return (
+    <div className="min-h-screen pt-16 bg-background">
+      <div className="container mx-auto px-6 pt-8 pb-20">
+        {/* Back link */}
+        <Link to="/marketplace?tab=challenges" className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="h-4 w-4" /> Back to Challenges
+        </Link>
+
+        {/* Status banner */}
+        {isClosed && (
+          <div className="flex items-center gap-2 px-4 py-3 rounded-xl border border-yellow-500/30 bg-yellow-500/5 mb-6">
+            <AlertTriangle className="h-4 w-4 text-yellow-400" />
+            <p className="text-sm text-yellow-400">This challenge is no longer accepting submissions.</p>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_360px] gap-8">
+          {/* Main content */}
+          <div className="space-y-6">
+            {/* Header */}
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[9px] font-semibold bg-secondary/15 text-secondary border border-secondary/25">
+                  <Target className="h-2.5 w-2.5" /> Challenge
+                </span>
+                <ChallengeStatusBadge status={challenge.status} />
+              </div>
+              <h1 className="text-3xl font-bold text-foreground mb-2">{challenge.title}</h1>
+              <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <Calendar className="h-3.5 w-3.5" />
+                  Created {new Date(challenge.created_at).toLocaleDateString()}
+                </span>
+                <span className="flex items-center gap-1">
+                  <MessageSquare className="h-3.5 w-3.5" />
+                  {challenge.submission_count} submission{challenge.submission_count !== 1 ? "s" : ""}
+                </span>
+              </div>
+            </div>
+
+            {/* Media gallery */}
+            {media.length > 0 && (
+              <div className="space-y-3">
+                <div className="rounded-2xl border border-border/40 bg-card/50 overflow-hidden">
+                  <div className="aspect-video flex items-center justify-center bg-muted/20">
+                    {activeMediaUrl && activeMediaItem ? (
+                      activeMediaItem.content_type.startsWith("video/") ? (
+                        <video
+                          key={activeMediaUrl}
+                          src={activeMediaUrl}
+                          controls
+                          className="w-full h-full object-contain"
+                        />
+                      ) : (
+                        <img src={activeMediaUrl} alt={activeMediaItem.file_name} className="w-full h-full object-contain" />
+                      )
+                    ) : (
+                      <Film className="h-12 w-12 text-muted-foreground/20" />
+                    )}
+                  </div>
+                </div>
+                {media.length > 1 && (
+                  <div className="flex gap-2 overflow-x-auto">
+                    {media.map((m) => {
+                      const url = mediaUrls.get(m.id);
+                      return (
+                        <button
+                          key={m.id}
+                          onClick={() => setActiveMedia(m.id)}
+                          className={`shrink-0 w-20 h-14 rounded-lg border overflow-hidden transition-all ${
+                            activeMedia === m.id ? "border-secondary ring-1 ring-secondary/50" : "border-border/30 opacity-60 hover:opacity-100"
+                          }`}
+                        >
+                          {url ? (
+                            m.content_type.startsWith("video/") ? (
+                              <video src={url} muted preload="metadata" className="w-full h-full object-cover"
+                                onLoadedData={(e) => { e.currentTarget.currentTime = 0.1; }} />
+                            ) : (
+                              <img src={url} alt="" className="w-full h-full object-cover" />
+                            )
+                          ) : (
+                            <div className="w-full h-full bg-muted/20 flex items-center justify-center">
+                              <Film className="h-3 w-3 text-muted-foreground/30" />
+                            </div>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Description */}
+            <GlassCard hover={false}>
+              <h2 className="text-sm font-semibold text-foreground mb-3">Description</h2>
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed">
+                {challenge.description || "No description provided."}
+              </p>
+            </GlassCard>
+
+            {/* Constraints */}
+            {challenge.constraints && (
+              <GlassCard hover={false}>
+                <h2 className="text-sm font-semibold text-foreground mb-3">Technical Constraints</h2>
+                <p className="text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed">
+                  {challenge.constraints}
+                </p>
+              </GlassCard>
+            )}
+
+            {/* Conditions */}
+            {challenge.conditions && (
+              <GlassCard hover={false}>
+                <h2 className="text-sm font-semibold text-foreground mb-3">Acceptance Conditions</h2>
+                <p className="text-sm text-muted-foreground whitespace-pre-wrap leading-relaxed">
+                  {challenge.conditions}
+                </p>
+              </GlassCard>
+            )}
+
+            {/* Tags */}
+            {challenge.tags.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {challenge.tags.map((tag) => (
+                  <span key={tag} className="px-3 py-1 rounded-full text-[10px] font-medium bg-muted/40 text-muted-foreground border border-border/30">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Owner: Submissions */}
+            {isOwner && submissions.length > 0 && (
+              <GlassCard hover={false}>
+                <h2 className="text-sm font-semibold text-foreground mb-4">
+                  Submissions ({submissions.length})
+                </h2>
+                <div className="space-y-3">
+                  {submissions.map((sub) => (
+                    <div key={sub.id} className="flex items-center justify-between rounded-xl border border-border/30 bg-background/30 p-3">
+                      <div className="min-w-0 flex-1">
+                        <p className="text-xs font-mono text-foreground truncate">{sub.dataset_id}</p>
+                        {sub.message && (
+                          <p className="text-[11px] text-muted-foreground mt-1 line-clamp-2">{sub.message}</p>
+                        )}
+                        <p className="text-[10px] text-muted-foreground mt-1">
+                          {new Date(sub.created_at).toLocaleDateString()} &middot;{" "}
+                          <span className={
+                            sub.status === "accepted" ? "text-green-400" :
+                            sub.status === "rejected" ? "text-red-400" : "text-yellow-400"
+                          }>
+                            {sub.status}
+                          </span>
+                        </p>
+                      </div>
+                      {sub.status === "pending" && (
+                        <div className="flex items-center gap-1.5 ml-3 shrink-0">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 gap-1 text-[10px] text-green-400 hover:text-green-400"
+                            onClick={() => handleSubmissionAction(sub.id, "accepted")}
+                          >
+                            <CheckCircle2 className="h-3 w-3" /> Accept
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 gap-1 text-[10px] text-red-400 hover:text-red-400"
+                            onClick={() => handleSubmissionAction(sub.id, "rejected")}
+                          >
+                            <XIcon className="h-3 w-3" /> Reject
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </GlassCard>
+            )}
+          </div>
+
+          {/* Sidebar */}
+          <div className="space-y-4">
+            {/* Compensation card */}
+            <GlassCard hover={false}>
+              <div className="flex items-center gap-2 mb-3">
+                <Trophy className="h-4 w-4 text-secondary" />
+                <span className="text-xs font-semibold text-foreground">Compensation</span>
+              </div>
+              {challenge.compensation_amount === 0 ? (
+                <p className="text-lg font-bold text-primary">Volunteer</p>
+              ) : (
+                <>
+                  <p className="text-2xl font-bold text-foreground">
+                    {formatPrice(challenge.compensation_amount, challenge.currency)}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground mt-1">
+                    {isLumpSum ? "Total budget (lump sum)" : "Per accepted dataset"}
+                  </p>
+                </>
+              )}
+            </GlassCard>
+
+            {/* Deadline card */}
+            <GlassCard hover={false}>
+              <div className="flex items-center gap-2 mb-3">
+                <Clock className="h-4 w-4 text-secondary" />
+                <span className="text-xs font-semibold text-foreground">Deadline</span>
+              </div>
+              {deadlineDate ? (
+                <>
+                  <p className={`text-sm font-semibold ${deadlinePassed ? "text-red-400" : "text-foreground"}`}>
+                    {deadlineDate.toLocaleDateString()}
+                  </p>
+                  {deadlinePassed && (
+                    <p className="text-[10px] text-red-400 mt-1">Deadline has passed</p>
+                  )}
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">No deadline</p>
+              )}
+            </GlassCard>
+
+            {/* Submit button */}
+            {isAuthenticated && !isOwner && isActive && (
+              <Button
+                variant="neon"
+                className="w-full gap-2"
+                onClick={() => setSubmitOpen(true)}
+              >
+                <Send className="h-4 w-4" /> Submit Dataset
+              </Button>
+            )}
+
+            {!isAuthenticated && isActive && (
+              <Link to="/login">
+                <Button variant="neon" className="w-full gap-2">
+                  <User className="h-4 w-4" /> Sign in to Submit
+                </Button>
+              </Link>
+            )}
+
+            {/* Owner controls */}
+            {isOwner && challenge.status !== "closed" && (
+              <GlassCard hover={false}>
+                <p className="text-xs font-semibold text-foreground mb-3">Manage Challenge</p>
+                <div className="space-y-2">
+                  {challenge.status === "active" && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="w-full justify-start gap-2 text-xs"
+                      onClick={() => handleToggleStatus("inactive")}
+                    >
+                      <ToggleLeft className="h-3.5 w-3.5" /> Deactivate
+                    </Button>
+                  )}
+                  {challenge.status === "inactive" && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="w-full justify-start gap-2 text-xs"
+                      onClick={() => handleToggleStatus("active")}
+                    >
+                      <ToggleRight className="h-3.5 w-3.5" /> Reactivate
+                    </Button>
+                  )}
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="w-full justify-start gap-2 text-xs text-destructive hover:text-destructive"
+                      >
+                        <XCircle className="h-3.5 w-3.5" /> Close Permanently
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Close this challenge?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This action is permanent. The challenge will no longer accept submissions and cannot be reopened.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleClose}>Close Challenge</AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              </GlassCard>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Submit modal */}
+      <SubmitDatasetModal
+        open={submitOpen}
+        onClose={() => setSubmitOpen(false)}
+        challengeId={challenge.id}
+        existingSubmissions={submissions}
+        onSubmitted={refreshSubmissions}
+      />
+    </div>
+  );
+};
+
+export default ChallengeDetailPage;

--- a/src/pages/ChallengeEditorPage.tsx
+++ b/src/pages/ChallengeEditorPage.tsx
@@ -104,7 +104,7 @@ const ChallengeEditorPage = () => {
       } else {
         const created = await challengeService.create(formData());
         setChallengeId(created.id);
-        navigate(`/dashboard/challenges/${created.id}`, { replace: true });
+        navigate(`/dashboard/challenges/${created.id}/edit`, { replace: true });
         toast.success("Challenge created as draft");
       }
     } catch (err: any) {

--- a/src/pages/ChallengeEditorPage.tsx
+++ b/src/pages/ChallengeEditorPage.tsx
@@ -1,0 +1,424 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import PageContainer from "@/layouts/PageContainer";
+import SectionHeader from "@/components/SectionHeader";
+import GlassCard from "@/components/GlassCard";
+import ChallengeMediaUpload from "@/components/ChallengeMediaUpload";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import {
+  SUPPORTED_CURRENCIES, DEFAULT_CURRENCY, formatPrice, getCurrency,
+} from "@/lib/marketplace";
+import type { CurrencyCode } from "@/lib/marketplace";
+import { challengeService } from "@/services/challengeService";
+import { useAuth } from "@/hooks/useAuth";
+import { toast } from "sonner";
+import {
+  Target, Save, Send, ArrowLeft, ArrowRight, CheckCircle2, Loader2,
+} from "lucide-react";
+
+const STEPS = ["Basic Info", "Media", "Compensation", "Review & Publish"] as const;
+
+const ChallengeEditorPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const isNew = !id;
+
+  const [step, setStep] = useState(0);
+  const [loading, setLoading] = useState(!isNew);
+  const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [challengeId, setChallengeId] = useState<string | null>(id ?? null);
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [compensationAmount, setCompensationAmount] = useState("");
+  const [compensationPer, setCompensationPer] = useState<"dataset" | "challenge">("dataset");
+  const [currency, setCurrency] = useState<CurrencyCode>(DEFAULT_CURRENCY);
+  const [isVolunteer, setIsVolunteer] = useState(true);
+  const [deadline, setDeadline] = useState("");
+  const [constraints, setConstraints] = useState("");
+  const [conditions, setConditions] = useState("");
+  const [tagInput, setTagInput] = useState("");
+  const [status, setStatus] = useState<"draft" | "active" | "inactive" | "closed">("draft");
+
+  useEffect(() => {
+    if (id) {
+      challengeService.get(id).then((c) => {
+        if (!c) { navigate("/dashboard"); return; }
+        setTitle(c.title);
+        setDescription(c.description);
+        setIsVolunteer(c.compensation_amount === 0);
+        if (c.compensation_amount > 0) {
+          const cur = getCurrency(c.currency);
+          setCompensationAmount(
+            cur.decimals > 0
+              ? (c.compensation_amount / Math.pow(10, cur.decimals)).toFixed(cur.decimals)
+              : c.compensation_amount.toString()
+          );
+        }
+        setCompensationPer(c.compensation_per);
+        setCurrency(c.currency as CurrencyCode);
+        setDeadline(c.deadline ? c.deadline.split("T")[0] : "");
+        setConstraints(c.constraints);
+        setConditions(c.conditions);
+        setTagInput(c.tags.join(", "));
+        setStatus(c.status);
+        setLoading(false);
+      });
+    }
+  }, [id, navigate]);
+
+  const currencyInfo = getCurrency(currency);
+  const priceAmount = isVolunteer
+    ? 0
+    : Math.round(parseFloat(compensationAmount || "0") * Math.pow(10, currencyInfo.decimals));
+
+  const formData = () => ({
+    title: title.trim(),
+    description: description.trim(),
+    compensation_amount: priceAmount,
+    compensation_per: compensationPer,
+    currency,
+    deadline: deadline ? new Date(deadline).toISOString() : null,
+    constraints: constraints.trim(),
+    conditions: conditions.trim(),
+    tags: tagInput.split(",").map((t) => t.trim()).filter(Boolean),
+  });
+
+  const handleSaveDraft = async () => {
+    if (!title.trim()) { toast.error("Title is required"); return; }
+    setSaving(true);
+    try {
+      if (challengeId) {
+        await challengeService.update(challengeId, formData());
+        toast.success("Draft saved");
+      } else {
+        const created = await challengeService.create(formData());
+        setChallengeId(created.id);
+        navigate(`/dashboard/challenges/${created.id}`, { replace: true });
+        toast.success("Challenge created as draft");
+      }
+    } catch (err: any) {
+      toast.error(err.message || "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const canPublish = title.trim() && description.trim();
+
+  const handlePublish = async () => {
+    if (!canPublish) { toast.error("Title and description are required"); return; }
+    setPublishing(true);
+    try {
+      let cid = challengeId;
+      if (!cid) {
+        const created = await challengeService.create(formData());
+        cid = created.id;
+      } else {
+        await challengeService.update(cid, formData());
+      }
+      await challengeService.publish(cid);
+      toast.success("Challenge published!");
+      navigate(`/marketplace/challenges/${cid}`);
+    } catch (err: any) {
+      toast.error(err.message || "Failed to publish");
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <PageContainer>
+        <div className="space-y-4">
+          <div className="h-10 w-48 rounded-xl bg-muted/20 animate-pulse" />
+          <div className="h-64 rounded-2xl bg-muted/20 animate-pulse" />
+        </div>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer>
+      <div className="max-w-3xl mx-auto">
+        <SectionHeader
+          title={isNew ? "Create Challenge" : "Edit Challenge"}
+          subtitle="Request datasets from the community to automate new tasks."
+        />
+
+        {/* Step indicator */}
+        <div className="flex items-center gap-2 mb-8">
+          {STEPS.map((label, i) => (
+            <button
+              key={label}
+              onClick={() => setStep(i)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[10px] font-semibold uppercase tracking-wider border transition-colors ${
+                i === step
+                  ? "border-secondary/50 bg-secondary/10 text-secondary"
+                  : i < step
+                  ? "border-primary/30 bg-primary/5 text-primary"
+                  : "border-border/40 bg-background/40 text-muted-foreground"
+              }`}
+            >
+              {i < step ? <CheckCircle2 className="h-3 w-3" /> : <span className="w-3 text-center">{i + 1}</span>}
+              <span className="hidden sm:inline">{label}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Step 1: Basic Info */}
+        {step === 0 && (
+          <GlassCard hover={false}>
+            <div className="space-y-5">
+              <div className="space-y-1.5">
+                <Label htmlFor="ch-title" className="text-xs">Title *</Label>
+                <Input
+                  id="ch-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="e.g., Kitchen object manipulation dataset"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="ch-desc" className="text-xs">Description *</Label>
+                <Textarea
+                  id="ch-desc"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Describe the task you want automated, the environment, objects involved, success criteria..."
+                  rows={6}
+                />
+              </div>
+            </div>
+          </GlassCard>
+        )}
+
+        {/* Step 2: Media */}
+        {step === 1 && (
+          <GlassCard hover={false}>
+            <div className="space-y-3">
+              <Label className="text-xs">Upload Videos & Images</Label>
+              <p className="text-[11px] text-muted-foreground">
+                Show the task you want automated. Videos and images help contributors understand the challenge.
+              </p>
+              {challengeId && user ? (
+                <ChallengeMediaUpload challengeId={challengeId} userId={user.id} />
+              ) : (
+                <p className="text-[11px] text-muted-foreground bg-muted/20 rounded-xl p-4 text-center">
+                  Save as draft first to upload media.
+                </p>
+              )}
+            </div>
+          </GlassCard>
+        )}
+
+        {/* Step 3: Compensation & Conditions */}
+        {step === 2 && (
+          <GlassCard hover={false}>
+            <div className="space-y-5">
+              {/* Compensation */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <Label className="text-xs">Compensation</Label>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[11px] text-muted-foreground">Volunteer (no pay)</span>
+                    <Switch checked={isVolunteer} onCheckedChange={setIsVolunteer} />
+                  </div>
+                </div>
+
+                {!isVolunteer && (
+                  <>
+                    <div className="grid grid-cols-[1fr_auto_auto] gap-3">
+                      <Input
+                        type="number"
+                        min="0"
+                        step={currencyInfo.decimals > 0 ? "0.01" : "1"}
+                        value={compensationAmount}
+                        onChange={(e) => setCompensationAmount(e.target.value)}
+                        placeholder="0.00"
+                        className="font-mono"
+                      />
+                      <Select value={currency} onValueChange={(v) => setCurrency(v as CurrencyCode)}>
+                        <SelectTrigger className="w-[100px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {SUPPORTED_CURRENCIES.map((c) => (
+                            <SelectItem key={c.code} value={c.code}>
+                              {c.symbol} {c.code}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Select value={compensationPer} onValueChange={(v) => setCompensationPer(v as "dataset" | "challenge")}>
+                        <SelectTrigger className="w-[130px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="dataset">Per dataset</SelectItem>
+                          <SelectItem value="challenge">Lump sum</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    {priceAmount > 0 && (
+                      <p className="text-[11px] text-muted-foreground">
+                        {compensationPer === "dataset"
+                          ? `Each accepted dataset earns the contributor ${formatPrice(priceAmount, currency)}`
+                          : `Total budget: ${formatPrice(priceAmount, currency)} for the winning submission`}
+                      </p>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {/* Deadline */}
+              <div className="space-y-1.5">
+                <Label htmlFor="ch-deadline" className="text-xs">Deadline (optional)</Label>
+                <Input
+                  id="ch-deadline"
+                  type="date"
+                  value={deadline}
+                  onChange={(e) => setDeadline(e.target.value)}
+                />
+              </div>
+
+              {/* Constraints */}
+              <div className="space-y-1.5">
+                <Label htmlFor="ch-constraints" className="text-xs">Technical Constraints</Label>
+                <Textarea
+                  id="ch-constraints"
+                  value={constraints}
+                  onChange={(e) => setConstraints(e.target.value)}
+                  placeholder="Robot type, sensor requirements, data format, minimum episodes..."
+                  rows={3}
+                />
+              </div>
+
+              {/* Conditions */}
+              <div className="space-y-1.5">
+                <Label htmlFor="ch-conditions" className="text-xs">Acceptance Conditions</Label>
+                <Textarea
+                  id="ch-conditions"
+                  value={conditions}
+                  onChange={(e) => setConditions(e.target.value)}
+                  placeholder="Success criteria, quality requirements, what makes a dataset acceptable..."
+                  rows={3}
+                />
+              </div>
+            </div>
+          </GlassCard>
+        )}
+
+        {/* Step 4: Tags & Review */}
+        {step === 3 && (
+          <GlassCard hover={false}>
+            <div className="space-y-5">
+              <div className="space-y-1.5">
+                <Label htmlFor="ch-tags" className="text-xs">Tags</Label>
+                <Input
+                  id="ch-tags"
+                  value={tagInput}
+                  onChange={(e) => setTagInput(e.target.value)}
+                  placeholder="manipulation, kitchen, depth (comma-separated)"
+                />
+              </div>
+
+              {/* Pre-publish checklist */}
+              <div className="rounded-xl border border-border/40 bg-background/40 p-4 space-y-2">
+                <p className="text-xs font-semibold text-foreground mb-2">Pre-publish checklist</p>
+                <ChecklistItem ok={!!title.trim()} label="Title set" />
+                <ChecklistItem ok={!!description.trim()} label="Description written" />
+                <ChecklistItem ok={isVolunteer || priceAmount > 0} label="Compensation configured" />
+                <ChecklistItem ok={!!constraints.trim() || !!conditions.trim()} label="Constraints or conditions specified" />
+              </div>
+
+              {/* Summary */}
+              <div className="rounded-xl border border-border/40 bg-background/40 p-4 space-y-2 text-[11px]">
+                <p className="text-xs font-semibold text-foreground mb-2">Summary</p>
+                <Row label="Title" value={title || "—"} />
+                <Row label="Compensation" value={
+                  isVolunteer ? "Volunteer" :
+                  `${formatPrice(priceAmount, currency)} ${compensationPer === "challenge" ? "(lump sum)" : "(per dataset)"}`
+                } />
+                <Row label="Deadline" value={deadline || "None"} />
+                <Row label="Tags" value={tagInput || "None"} />
+              </div>
+
+              <Button
+                variant="neon"
+                className="w-full gap-2"
+                onClick={handlePublish}
+                disabled={publishing || !canPublish || status === "active"}
+              >
+                {publishing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                {status === "active" ? "Already Published" : "Publish Challenge"}
+              </Button>
+            </div>
+          </GlassCard>
+        )}
+
+        {/* Navigation */}
+        <div className="flex items-center justify-between mt-6">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setStep(Math.max(0, step - 1))}
+            disabled={step === 0}
+            className="gap-1.5"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" /> Back
+          </Button>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleSaveDraft}
+              disabled={saving || status !== "draft"}
+              className="gap-1.5"
+            >
+              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+              Save Draft
+            </Button>
+            {step < STEPS.length - 1 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setStep(step + 1)}
+                className="gap-1.5"
+              >
+                Next <ArrowRight className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </PageContainer>
+  );
+};
+
+const ChecklistItem = ({ ok, label }: { ok: boolean; label: string }) => (
+  <div className="flex items-center gap-2 text-[11px]">
+    <CheckCircle2 className={`h-3.5 w-3.5 ${ok ? "text-green-400" : "text-muted-foreground/30"}`} />
+    <span className={ok ? "text-foreground" : "text-muted-foreground"}>{label}</span>
+  </div>
+);
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-center justify-between">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="text-foreground font-medium">{value}</span>
+  </div>
+);
+
+export default ChallengeEditorPage;

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,12 +1,21 @@
 import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import PageContainer from "@/layouts/PageContainer";
 import SectionHeader from "@/components/SectionHeader";
 import GlassCard from "@/components/GlassCard";
 import DatasetListCard from "@/components/DatasetListCard";
+import ChallengeListCard from "@/components/ChallengeListCard";
 import { listDatasets } from "@/services/datasetService";
+import { challengeService } from "@/services/challengeService";
 import type { DatasetListItem } from "@/services/datasetService";
-import { Layers, HardDrive, Database, Activity } from "lucide-react";
-import { Link } from "react-router-dom";
+import type { Challenge } from "@/types";
+import { Layers, HardDrive, Database, Activity, Target, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
 
 const formatBytes = (bytes: number) => {
   if (bytes === 0) return "0 B";
@@ -17,14 +26,21 @@ const formatBytes = (bytes: number) => {
 };
 
 const DashboardPage = () => {
+  const navigate = useNavigate();
   const [datasets, setDatasets] = useState<DatasetListItem[]>([]);
+  const [challenges, setChallenges] = useState<Challenge[]>([]);
   const [loading, setLoading] = useState(true);
+  const [closeConfirmId, setCloseConfirmId] = useState<string | null>(null);
 
   useEffect(() => {
-    listDatasets()
-      .then(setDatasets)
-      .catch((err) => console.error("Dashboard load error:", err))
-      .finally(() => setLoading(false));
+    Promise.all([
+      listDatasets(),
+      challengeService.listMine(),
+    ]).then(([ds, ch]) => {
+      setDatasets(ds);
+      setChallenges(ch);
+    }).catch((err) => console.error("Dashboard load error:", err))
+    .finally(() => setLoading(false));
   }, []);
 
   const totalSize = datasets.reduce((a, d) => a + d.total_size_bytes, 0);
@@ -33,8 +49,49 @@ const DashboardPage = () => {
     { icon: Database, label: "Datasets", value: datasets.length },
     { icon: Layers, label: "Total Files", value: datasets.reduce((a, d) => a + d.file_count, 0) },
     { icon: HardDrive, label: "Total Data", value: formatBytes(totalSize) },
-    { icon: Activity, label: "Downloads", value: 0 },
+    { icon: Target, label: "Challenges", value: challenges.length },
   ];
+
+  const handlePublish = async (id: string) => {
+    try {
+      await challengeService.publish(id);
+      setChallenges((prev) => prev.map((c) => c.id === id ? { ...c, status: "active" as const } : c));
+      toast.success("Challenge published!");
+    } catch (err: any) {
+      toast.error(err.message || "Failed to publish");
+    }
+  };
+
+  const handleToggleStatus = async (id: string, status: "active" | "inactive") => {
+    try {
+      await challengeService.setStatus(id, status);
+      setChallenges((prev) => prev.map((c) => c.id === id ? { ...c, status } : c));
+      toast.success(`Challenge ${status === "active" ? "activated" : "deactivated"}`);
+    } catch (err: any) {
+      toast.error(err.message || "Failed to update");
+    }
+  };
+
+  const handleClose = async (id: string) => {
+    try {
+      await challengeService.setStatus(id, "closed");
+      setChallenges((prev) => prev.map((c) => c.id === id ? { ...c, status: "closed" as const } : c));
+      toast.success("Challenge closed");
+    } catch (err: any) {
+      toast.error(err.message || "Failed to close");
+    }
+    setCloseConfirmId(null);
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await challengeService.deleteDraft(id);
+      setChallenges((prev) => prev.filter((c) => c.id !== id));
+      toast.success("Draft deleted");
+    } catch (err: any) {
+      toast.error(err.message || "Failed to delete");
+    }
+  };
 
   return (
     <PageContainer>
@@ -83,8 +140,63 @@ const DashboardPage = () => {
               ))}
             </div>
           )}
+
+          {/* Challenges */}
+          <div className="mt-12">
+            <div className="flex items-center justify-between mb-6">
+              <SectionHeader title="Challenges" className="mb-0" />
+              <Button
+                variant="neon"
+                size="sm"
+                className="gap-1.5"
+                onClick={() => navigate("/dashboard/challenges/new")}
+                data-testid="create-challenge-btn"
+              >
+                <Plus className="h-3.5 w-3.5" /> Create Challenge
+              </Button>
+            </div>
+            {challenges.length === 0 ? (
+              <GlassCard hover={false} className="text-center py-12">
+                <Target className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
+                <p className="text-sm text-muted-foreground">
+                  No challenges yet. Create one to request datasets from the community.
+                </p>
+              </GlassCard>
+            ) : (
+              <div className="space-y-3">
+                {challenges.map((ch) => (
+                  <ChallengeListCard
+                    key={ch.id}
+                    challenge={ch}
+                    onPublish={handlePublish}
+                    onToggleStatus={handleToggleStatus}
+                    onClose={(id) => setCloseConfirmId(id)}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         </>
       )}
+
+      {/* Close confirmation dialog */}
+      <AlertDialog open={!!closeConfirmId} onOpenChange={() => setCloseConfirmId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Close this challenge?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action is permanent. The challenge will no longer accept submissions and cannot be reopened.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => closeConfirmId && handleClose(closeConfirmId)}>
+              Close Challenge
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </PageContainer>
   );
 };

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -7,9 +7,11 @@ import DatasetListCard from "@/components/DatasetListCard";
 import ChallengeListCard from "@/components/ChallengeListCard";
 import { listDatasets } from "@/services/datasetService";
 import { challengeService } from "@/services/challengeService";
+import { challengeSubmissionService } from "@/services/challengeSubmissionService";
 import type { DatasetListItem } from "@/services/datasetService";
-import type { Challenge } from "@/types";
-import { Layers, HardDrive, Database, Activity, Target, Plus } from "lucide-react";
+import type { Challenge, ParticipantSubmissionItem } from "@/types";
+import { formatPrice } from "@/lib/marketplace";
+import { Layers, HardDrive, Database, Target, Plus, Send } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
@@ -29,6 +31,7 @@ const DashboardPage = () => {
   const navigate = useNavigate();
   const [datasets, setDatasets] = useState<DatasetListItem[]>([]);
   const [challenges, setChallenges] = useState<Challenge[]>([]);
+  const [submissions, setSubmissions] = useState<ParticipantSubmissionItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [closeConfirmId, setCloseConfirmId] = useState<string | null>(null);
 
@@ -36,12 +39,16 @@ const DashboardPage = () => {
     Promise.allSettled([
       listDatasets(),
       challengeService.listMine(),
-    ]).then(([dsResult, chResult]) => {
+      challengeSubmissionService.listMineEnriched(),
+    ]).then(([dsResult, chResult, subResult]) => {
       if (dsResult.status === "fulfilled") setDatasets(dsResult.value);
       else console.error("Dashboard datasets error:", dsResult.reason);
 
       if (chResult.status === "fulfilled") setChallenges(chResult.value);
       else console.warn("Dashboard challenges error (table may not exist yet):", chResult.reason);
+
+      if (subResult.status === "fulfilled") setSubmissions(subResult.value);
+      else console.warn("Dashboard challenge submissions error:", subResult.reason);
     }).finally(() => setLoading(false));
   }, []);
 
@@ -94,6 +101,39 @@ const DashboardPage = () => {
       toast.error(err.message || "Failed to delete");
     }
   };
+
+  const handleWithdraw = async (id: string) => {
+    try {
+      await challengeSubmissionService.withdraw(id);
+      setSubmissions((prev) => prev.filter((s) => s.id !== id));
+      toast.success("Submission withdrawn");
+    } catch (err: any) {
+      toast.error(err.message || "Failed to withdraw submission");
+    }
+  };
+
+  const groupedSubmissions = submissions.reduce((acc, item) => {
+    const key = item.challenge?.id || item.challenge_id;
+    if (!acc[key]) {
+      acc[key] = {
+        challengeId: item.challenge_id,
+        challengeTitle: item.challenge?.title || "Unknown challenge",
+        challengeCompensationAmount: item.challenge?.compensation_amount ?? 0,
+        challengeCompensationPer: item.challenge?.compensation_per ?? "dataset",
+        challengeCurrency: item.challenge?.currency ?? "USD",
+        entries: [] as ParticipantSubmissionItem[],
+      };
+    }
+    acc[key].entries.push(item);
+    return acc;
+  }, {} as Record<string, {
+    challengeId: string;
+    challengeTitle: string;
+    challengeCompensationAmount: number;
+    challengeCompensationPer: "dataset" | "challenge";
+    challengeCurrency: string;
+    entries: ParticipantSubmissionItem[];
+  }>);
 
   return (
     <PageContainer>
@@ -175,6 +215,82 @@ const DashboardPage = () => {
                     onClose={(id) => setCloseConfirmId(id)}
                     onDelete={handleDelete}
                   />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* My Submissions */}
+          <div className="mt-12">
+            <SectionHeader title="My Submissions" className="mb-6" />
+            {Object.keys(groupedSubmissions).length === 0 ? (
+              <GlassCard hover={false} className="text-center py-12">
+                <Send className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
+                <p className="text-sm text-muted-foreground">
+                  You have not submitted any datasets to challenges yet.
+                </p>
+              </GlassCard>
+            ) : (
+              <div className="space-y-4">
+                {Object.values(groupedSubmissions).map((group) => (
+                  <GlassCard key={group.challengeId} hover={false}>
+                    <div className="flex items-center justify-between gap-2 mb-3">
+                      <Link
+                        to={`/marketplace/challenges/${group.challengeId}`}
+                        className="text-sm font-semibold text-foreground hover:text-secondary transition-colors"
+                      >
+                        {group.challengeTitle}
+                      </Link>
+                      <span className="text-[10px] text-muted-foreground">
+                        {group.entries.length} submission{group.entries.length !== 1 ? "s" : ""}
+                      </span>
+                    </div>
+                    <div className="space-y-2">
+                      {group.entries.map((sub) => (
+                        <div
+                          key={sub.id}
+                          className="rounded-xl border border-border/30 bg-background/30 p-3 flex items-center justify-between gap-3"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <p className="text-xs font-medium text-foreground truncate">
+                              {sub.dataset_display_name || sub.dataset_id}
+                            </p>
+                            <p className="text-[10px] text-muted-foreground mt-1">
+                              Submitted {new Date(sub.created_at).toLocaleDateString()}
+                            </p>
+                            <p className="text-[10px] mt-1">
+                              Status:{" "}
+                              <span className={
+                                sub.status === "accepted"
+                                  ? "text-green-400"
+                                  : sub.status === "rejected"
+                                  ? "text-red-400"
+                                  : "text-yellow-400"
+                              }>
+                                {sub.status}
+                              </span>
+                            </p>
+                            {sub.status === "accepted" && (
+                              <p className="text-[10px] text-green-400 mt-1">
+                                Earned {formatPrice(group.challengeCompensationAmount, group.challengeCurrency)}{" "}
+                                {group.challengeCompensationPer === "challenge" ? "(lump sum)" : "per accepted dataset"}
+                              </p>
+                            )}
+                          </div>
+                          {sub.status === "pending" && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 text-xs text-destructive hover:text-destructive"
+                              onClick={() => handleWithdraw(sub.id)}
+                            >
+                              Withdraw
+                            </Button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </GlassCard>
                 ))}
               </div>
             )}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -33,14 +33,16 @@ const DashboardPage = () => {
   const [closeConfirmId, setCloseConfirmId] = useState<string | null>(null);
 
   useEffect(() => {
-    Promise.all([
+    Promise.allSettled([
       listDatasets(),
       challengeService.listMine(),
-    ]).then(([ds, ch]) => {
-      setDatasets(ds);
-      setChallenges(ch);
-    }).catch((err) => console.error("Dashboard load error:", err))
-    .finally(() => setLoading(false));
+    ]).then(([dsResult, chResult]) => {
+      if (dsResult.status === "fulfilled") setDatasets(dsResult.value);
+      else console.error("Dashboard datasets error:", dsResult.reason);
+
+      if (chResult.status === "fulfilled") setChallenges(chResult.value);
+      else console.warn("Dashboard challenges error (table may not exist yet):", chResult.reason);
+    }).finally(() => setLoading(false));
   }, []);
 
   const totalSize = datasets.reduce((a, d) => a + d.total_size_bytes, 0);

--- a/src/pages/MarketplacePage.tsx
+++ b/src/pages/MarketplacePage.tsx
@@ -1,25 +1,61 @@
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { listingService } from "@/services/listingService";
+import { challengeService } from "@/services/challengeService";
 import MarketplaceCard from "@/components/MarketplaceCard";
-import type { EnrichedListing } from "@/types";
-import { Search, Store, Tag } from "lucide-react";
+import ChallengeCard from "@/components/ChallengeCard";
+import type { EnrichedListing, EnrichedChallenge } from "@/types";
+import { Search, Store, Tag, Target } from "lucide-react";
+
+type Tab = "datasets" | "challenges";
 
 const MarketplacePage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = (searchParams.get("tab") as Tab) || "datasets";
   const [listings, setListings] = useState<EnrichedListing[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [query, setQuery] = useState("");
-  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [challenges, setChallenges] = useState<EnrichedChallenge[]>([]);
+  const [loadingDatasets, setLoadingDatasets] = useState(true);
+  const [loadingChallenges, setLoadingChallenges] = useState(true);
+  const [query, setQuery] = useState(searchParams.get("q") || "");
+  const [activeTag, setActiveTag] = useState<string | null>(searchParams.get("tag") || null);
 
   useEffect(() => {
+    let cancelled = false;
+
     listingService.listEnriched().then((l) => {
+      if (cancelled) return;
       setListings(l);
-      setLoading(false);
-    }).catch(() => setLoading(false));
+      setLoadingDatasets(false);
+    }).catch(() => {
+      if (cancelled) return;
+      setLoadingDatasets(false);
+    });
+
+    challengeService.listEnriched().then((c) => {
+      if (cancelled) return;
+      setChallenges(c);
+      setLoadingChallenges(false);
+    }).catch(() => {
+      if (cancelled) return;
+      setLoadingChallenges(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  const allTags = [...new Set(listings.flatMap((l) => l.tags))];
+  const setTab = (t: Tab) => {
+    const params = new URLSearchParams(searchParams);
+    params.set("tab", t);
+    setSearchParams(params, { replace: true });
+  };
 
-  const filtered = listings.filter((l) => {
+  const allDatasetTags = [...new Set(listings.flatMap((l) => l.tags))];
+  const allChallengeTags = [...new Set(challenges.flatMap((c) => c.tags))];
+  const allTags = tab === "datasets" ? allDatasetTags : allChallengeTags;
+
+  const filteredListings = listings.filter((l) => {
     const q = query.toLowerCase();
     const matchQuery =
       !q ||
@@ -29,6 +65,19 @@ const MarketplacePage = () => {
     const matchTag = !activeTag || l.tags.includes(activeTag);
     return matchQuery && matchTag;
   });
+
+  const filteredChallenges = challenges.filter((c) => {
+    const q = query.toLowerCase();
+    const matchQuery =
+      !q ||
+      c.title.toLowerCase().includes(q) ||
+      c.description.toLowerCase().includes(q) ||
+      c.tags.some((t) => t.toLowerCase().includes(q));
+    const matchTag = !activeTag || c.tags.includes(activeTag);
+    return matchQuery && matchTag;
+  });
+
+  const loading = tab === "datasets" ? loadingDatasets : loadingChallenges;
 
   return (
     <div className="min-h-screen pt-16 bg-background">
@@ -41,15 +90,45 @@ const MarketplacePage = () => {
           <div className="text-center mb-10">
             <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full border border-secondary/20 bg-secondary/5 mb-6">
               <Store className="h-3.5 w-3.5 text-secondary" />
-              <span className="text-xs font-medium text-secondary">Dataset Marketplace</span>
+              <span className="text-xs font-medium text-secondary">Marketplace</span>
             </div>
             <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-4 tracking-tight">
               Discover robotics{" "}
-              <span className="bg-clip-text text-transparent bg-[image:var(--gradient-neon)]">datasets</span>
+              <span className="bg-clip-text text-transparent bg-[image:var(--gradient-neon)]">
+                {tab === "datasets" ? "datasets" : "challenges"}
+              </span>
             </h1>
             <p className="text-muted-foreground text-sm max-w-lg mx-auto">
-              Browse high-quality datasets from the community. Free and premium options available.
+              {tab === "datasets"
+                ? "Browse high-quality datasets from the community. Free and premium options available."
+                : "Find challenges requesting datasets for new robotic tasks. Submit your data and get compensated."}
             </p>
+          </div>
+
+          {/* Tabs */}
+          <div className="flex items-center justify-center gap-2 mb-6">
+            <button
+              onClick={() => { setTab("datasets"); setActiveTag(null); }}
+              className={`flex items-center gap-1.5 px-5 py-2 rounded-full text-xs font-semibold transition-colors border ${
+                tab === "datasets"
+                  ? "border-primary/50 bg-primary/10 text-primary"
+                  : "border-border/40 bg-background/40 text-muted-foreground hover:text-foreground hover:border-primary/30"
+              }`}
+              data-testid="tab-datasets"
+            >
+              <Store className="h-3.5 w-3.5" /> Datasets
+            </button>
+            <button
+              onClick={() => { setTab("challenges"); setActiveTag(null); }}
+              className={`flex items-center gap-1.5 px-5 py-2 rounded-full text-xs font-semibold transition-colors border ${
+                tab === "challenges"
+                  ? "border-secondary/50 bg-secondary/10 text-secondary"
+                  : "border-border/40 bg-background/40 text-muted-foreground hover:text-foreground hover:border-secondary/30"
+              }`}
+              data-testid="tab-challenges"
+            >
+              <Target className="h-3.5 w-3.5" /> Challenges
+            </button>
           </div>
 
           {/* Search bar */}
@@ -60,7 +139,7 @@ const MarketplacePage = () => {
                 <Search className="h-5 w-5 text-secondary ml-5 shrink-0" />
                 <input
                   type="text"
-                  placeholder="Search datasets by name, description, or tag..."
+                  placeholder={`Search ${tab} by name, description, or tag...`}
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   className="flex-1 bg-transparent py-4 px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
@@ -106,22 +185,42 @@ const MarketplacePage = () => {
               <div key={i} className="h-80 rounded-2xl bg-muted/20 animate-pulse" />
             ))}
           </div>
-        ) : filtered.length === 0 ? (
-          <div className="text-center py-20">
-            <Tag className="h-10 w-10 text-muted-foreground/40 mx-auto mb-4" />
-            <p className="text-muted-foreground text-sm">No datasets match your filters.</p>
-          </div>
-        ) : (
-          <>
-            <p className="text-xs text-muted-foreground mb-6">
-              {filtered.length} dataset{filtered.length !== 1 ? "s" : ""} available
-            </p>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filtered.map((listing) => (
-                <MarketplaceCard key={listing.id} listing={listing} />
-              ))}
+        ) : tab === "datasets" ? (
+          filteredListings.length === 0 ? (
+            <div className="text-center py-20">
+              <Tag className="h-10 w-10 text-muted-foreground/40 mx-auto mb-4" />
+              <p className="text-muted-foreground text-sm">No datasets match your filters.</p>
             </div>
-          </>
+          ) : (
+            <>
+              <p className="text-xs text-muted-foreground mb-6">
+                {filteredListings.length} dataset{filteredListings.length !== 1 ? "s" : ""} available
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {filteredListings.map((listing) => (
+                  <MarketplaceCard key={listing.id} listing={listing} />
+                ))}
+              </div>
+            </>
+          )
+        ) : (
+          filteredChallenges.length === 0 ? (
+            <div className="text-center py-20">
+              <Target className="h-10 w-10 text-muted-foreground/40 mx-auto mb-4" />
+              <p className="text-muted-foreground text-sm">No challenges yet. Be the first to create one!</p>
+            </div>
+          ) : (
+            <>
+              <p className="text-xs text-muted-foreground mb-6">
+                {filteredChallenges.length} challenge{filteredChallenges.length !== 1 ? "s" : ""} available
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                {filteredChallenges.map((challenge) => (
+                  <ChallengeCard key={challenge.id} challenge={challenge} />
+                ))}
+              </div>
+            </>
+          )
         )}
       </div>
     </div>

--- a/src/services/challengeMediaService.ts
+++ b/src/services/challengeMediaService.ts
@@ -1,0 +1,80 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { ChallengeMedia } from "@/types";
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100);
+}
+
+export const challengeMediaService = {
+  async upload(challengeId: string, userId: string, file: File): Promise<ChallengeMedia> {
+    const uuid = typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : Array.from(crypto.getRandomValues(new Uint8Array(16)))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("")
+          .replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, "$1-$2-$3-$4-$5");
+    const safeName = sanitizeFilename(file.name);
+    const storagePath = `${userId}/${challengeId}/${uuid}-${safeName}`;
+
+    const { error: uploadError } = await supabase.storage
+      .from("challenge-media")
+      .upload(storagePath, file, { contentType: file.type });
+    if (uploadError) throw uploadError;
+
+    const { data, error } = await supabase
+      .from("challenge_media")
+      .insert({
+        challenge_id: challengeId,
+        user_id: userId,
+        storage_path: storagePath,
+        file_name: file.name,
+        content_type: file.type,
+        size_bytes: file.size,
+      })
+      .select()
+      .single();
+    if (error) throw error;
+    return data as unknown as ChallengeMedia;
+  },
+
+  async list(challengeId: string): Promise<ChallengeMedia[]> {
+    const { data, error } = await supabase
+      .from("challenge_media")
+      .select("*")
+      .eq("challenge_id", challengeId)
+      .order("sort_order", { ascending: true });
+    if (error) throw error;
+    return (data ?? []) as unknown as ChallengeMedia[];
+  },
+
+  async getSignedUrl(storagePath: string): Promise<string> {
+    const { data, error } = await supabase.storage
+      .from("challenge-media")
+      .createSignedUrl(storagePath, 60);
+    if (error) throw error;
+    return data.signedUrl;
+  },
+
+  async delete(mediaId: string, storagePath: string): Promise<void> {
+    const { error: storageError } = await supabase.storage
+      .from("challenge-media")
+      .remove([storagePath]);
+    if (storageError) throw storageError;
+
+    const { error } = await supabase
+      .from("challenge_media")
+      .delete()
+      .eq("id", mediaId);
+    if (error) throw error;
+  },
+
+  async reorder(items: { id: string; sort_order: number }[]): Promise<void> {
+    for (const item of items) {
+      const { error } = await supabase
+        .from("challenge_media")
+        .update({ sort_order: item.sort_order })
+        .eq("id", item.id);
+      if (error) throw error;
+    }
+  },
+};

--- a/src/services/challengeService.ts
+++ b/src/services/challengeService.ts
@@ -1,0 +1,158 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Challenge, EnrichedChallenge } from "@/types";
+
+export const challengeService = {
+  async listEnriched(): Promise<EnrichedChallenge[]> {
+    const { data: challenges, error } = await supabase
+      .from("challenges")
+      .select("*")
+      .eq("status", "active")
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    if (!challenges || challenges.length === 0) return [];
+
+    const userIds = [...new Set(challenges.map((c: any) => c.user_id))] as string[];
+    const { data: profiles, error: profError } = await supabase
+      .from("profiles")
+      .select("id, name")
+      .in("id", userIds);
+    if (profError) throw profError;
+
+    const profileMap = new Map<string, string>();
+    for (const p of profiles ?? []) {
+      profileMap.set(p.id, p.name || "Unknown");
+    }
+
+    const challengeIds = challenges.map((c: any) => c.id) as string[];
+    const { data: media, error: mediaError } = await supabase
+      .from("challenge_media")
+      .select("challenge_id, storage_path")
+      .in("challenge_id", challengeIds)
+      .order("sort_order", { ascending: true });
+    if (mediaError) throw mediaError;
+
+    const previewMap = new Map<string, string>();
+    for (const m of media ?? []) {
+      if (!previewMap.has((m as any).challenge_id)) {
+        previewMap.set((m as any).challenge_id, (m as any).storage_path);
+      }
+    }
+
+    const enriched: EnrichedChallenge[] = [];
+    for (const c of challenges) {
+      const ch = c as unknown as Challenge;
+      let previewUrl: string | null = null;
+      const storagePath = previewMap.get(ch.id);
+      if (storagePath) {
+        const { data: urlData } = await supabase.storage
+          .from("challenge-media")
+          .createSignedUrl(storagePath, 60);
+        previewUrl = urlData?.signedUrl ?? null;
+      }
+      enriched.push({
+        ...ch,
+        creator_name: profileMap.get(ch.user_id) || "Unknown",
+        preview_url: previewUrl,
+      });
+    }
+
+    return enriched;
+  },
+
+  async listMine(): Promise<Challenge[]> {
+    const { data, error } = await supabase
+      .from("challenges")
+      .select("*")
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return (data ?? []) as unknown as Challenge[];
+  },
+
+  async get(id: string): Promise<Challenge | undefined> {
+    const { data, error } = await supabase
+      .from("challenges")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+    if (error) throw error;
+    return (data as unknown as Challenge) ?? undefined;
+  },
+
+  async create(input: {
+    title: string;
+    description: string;
+    compensation_amount: number;
+    compensation_per: "dataset" | "challenge";
+    currency: string;
+    deadline: string | null;
+    constraints: string;
+    conditions: string;
+    tags: string[];
+  }): Promise<Challenge> {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error("Not authenticated");
+
+    const { data, error } = await supabase
+      .from("challenges")
+      .insert({
+        user_id: user.id,
+        ...input,
+        status: "draft",
+      })
+      .select()
+      .single();
+    if (error) throw error;
+    return data as unknown as Challenge;
+  },
+
+  async update(
+    id: string,
+    updates: Partial<Pick<Challenge,
+      "title" | "description" | "compensation_amount" | "compensation_per" |
+      "currency" | "deadline" | "constraints" | "conditions" | "tags"
+    >>
+  ): Promise<Challenge> {
+    const { data, error } = await supabase
+      .from("challenges")
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) throw error;
+    return data as unknown as Challenge;
+  },
+
+  async publish(id: string): Promise<Challenge> {
+    const { data, error } = await supabase
+      .from("challenges")
+      .update({ status: "active" })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) throw error;
+    return data as unknown as Challenge;
+  },
+
+  async setStatus(id: string, status: "active" | "inactive" | "closed"): Promise<Challenge> {
+    const { data, error } = await supabase
+      .from("challenges")
+      .update({ status })
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) throw error;
+    return data as unknown as Challenge;
+  },
+
+  async deleteDraft(id: string): Promise<void> {
+    const challenge = await this.get(id);
+    if (!challenge) throw new Error("Challenge not found");
+    if (challenge.status !== "draft") throw new Error("Only draft challenges can be deleted");
+
+    const { error } = await supabase
+      .from("challenges")
+      .delete()
+      .eq("id", id);
+    if (error) throw error;
+  },
+};

--- a/src/services/challengeService.ts
+++ b/src/services/challengeService.ts
@@ -60,9 +60,12 @@ export const challengeService = {
   },
 
   async listMine(): Promise<Challenge[]> {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return [];
     const { data, error } = await supabase
       .from("challenges")
       .select("*")
+      .eq("user_id", user.id)
       .order("created_at", { ascending: false });
     if (error) throw error;
     return (data ?? []) as unknown as Challenge[];

--- a/src/services/challengeSubmissionService.ts
+++ b/src/services/challengeSubmissionService.ts
@@ -1,5 +1,9 @@
 import { supabase } from "@/integrations/supabase/client";
-import type { ChallengeSubmission } from "@/types";
+import type {
+  ChallengeSubmission,
+  ChallengeSubmissionEnriched,
+  ParticipantSubmissionItem,
+} from "@/types";
 
 export const challengeSubmissionService = {
   async submit(data: {
@@ -32,19 +36,105 @@ export const challengeSubmissionService = {
     return (data ?? []) as unknown as ChallengeSubmission[];
   },
 
+  async listForChallengeEnriched(challengeId: string): Promise<ChallengeSubmissionEnriched[]> {
+    const rows = await this.listForChallenge(challengeId);
+    if (rows.length === 0) return [];
+
+    const datasetIds = [...new Set(rows.map((r) => r.dataset_id))];
+    const submitterIds = [...new Set(rows.map((r) => r.submitter_id))];
+
+    const [{ data: datasets, error: dsError }, { data: profiles, error: pError }] = await Promise.all([
+      supabase
+        .from("datasets")
+        .select("id, display_name")
+        .in("id", datasetIds),
+      supabase
+        .from("profiles")
+        .select("id, name")
+        .in("id", submitterIds),
+    ]);
+    if (dsError) throw dsError;
+    if (pError) throw pError;
+
+    const datasetMap = new Map<string, string>();
+    const submitterMap = new Map<string, string>();
+
+    for (const d of datasets ?? []) {
+      datasetMap.set((d as any).id, (d as any).display_name ?? "");
+    }
+    for (const p of profiles ?? []) {
+      submitterMap.set((p as any).id, (p as any).name ?? "Unknown");
+    }
+
+    return rows.map((row) => ({
+      ...row,
+      dataset_display_name: datasetMap.get(row.dataset_id) ?? null,
+      submitter_name: submitterMap.get(row.submitter_id) ?? null,
+    }));
+  },
+
   async listMine(): Promise<ChallengeSubmission[]> {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return [];
+
     const { data, error } = await supabase
       .from("challenge_submissions")
       .select("*")
+      .eq("submitter_id", user.id)
       .order("created_at", { ascending: false });
     if (error) throw error;
     return (data ?? []) as unknown as ChallengeSubmission[];
+  },
+
+  async listMineEnriched(): Promise<ParticipantSubmissionItem[]> {
+    const rows = await this.listMine();
+    if (rows.length === 0) return [];
+
+    const challengeIds = [...new Set(rows.map((r) => r.challenge_id))];
+    const datasetIds = [...new Set(rows.map((r) => r.dataset_id))];
+
+    const [{ data: challenges, error: chError }, { data: datasets, error: dsError }] = await Promise.all([
+      supabase
+        .from("challenges")
+        .select("id, title, compensation_amount, compensation_per, currency, status")
+        .in("id", challengeIds),
+      supabase
+        .from("datasets")
+        .select("id, display_name")
+        .in("id", datasetIds),
+    ]);
+    if (chError) throw chError;
+    if (dsError) throw dsError;
+
+    const challengeMap = new Map<string, ParticipantSubmissionItem["challenge"]>();
+    const datasetMap = new Map<string, string>();
+
+    for (const ch of challenges ?? []) {
+      challengeMap.set((ch as any).id, (ch as any));
+    }
+    for (const ds of datasets ?? []) {
+      datasetMap.set((ds as any).id, (ds as any).display_name ?? "");
+    }
+
+    return rows.map((row) => ({
+      ...row,
+      challenge: challengeMap.get(row.challenge_id) ?? null,
+      dataset_display_name: datasetMap.get(row.dataset_id) ?? null,
+    }));
   },
 
   async updateStatus(id: string, status: "accepted" | "rejected"): Promise<void> {
     const { error } = await supabase
       .from("challenge_submissions")
       .update({ status, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (error) throw error;
+  },
+
+  async withdraw(id: string): Promise<void> {
+    const { error } = await supabase
+      .from("challenge_submissions")
+      .delete()
       .eq("id", id);
     if (error) throw error;
   },

--- a/src/services/challengeSubmissionService.ts
+++ b/src/services/challengeSubmissionService.ts
@@ -1,0 +1,51 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { ChallengeSubmission } from "@/types";
+
+export const challengeSubmissionService = {
+  async submit(data: {
+    challenge_id: string;
+    dataset_id: string;
+    message: string;
+  }): Promise<ChallengeSubmission> {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) throw new Error("Not authenticated");
+
+    const { data: result, error } = await supabase
+      .from("challenge_submissions")
+      .insert({
+        ...data,
+        submitter_id: user.id,
+      })
+      .select()
+      .single();
+    if (error) throw error;
+    return result as unknown as ChallengeSubmission;
+  },
+
+  async listForChallenge(challengeId: string): Promise<ChallengeSubmission[]> {
+    const { data, error } = await supabase
+      .from("challenge_submissions")
+      .select("*")
+      .eq("challenge_id", challengeId)
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return (data ?? []) as unknown as ChallengeSubmission[];
+  },
+
+  async listMine(): Promise<ChallengeSubmission[]> {
+    const { data, error } = await supabase
+      .from("challenge_submissions")
+      .select("*")
+      .order("created_at", { ascending: false });
+    if (error) throw error;
+    return (data ?? []) as unknown as ChallengeSubmission[];
+  },
+
+  async updateStatus(id: string, status: "accepted" | "rejected"): Promise<void> {
+    const { error } = await supabase
+      .from("challenge_submissions")
+      .update({ status, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (error) throw error;
+  },
+};

--- a/src/test/helpers/factories.ts
+++ b/src/test/helpers/factories.ts
@@ -10,6 +10,8 @@ import type {
   APIKey,
   Listing,
   Order,
+  Challenge,
+  EnrichedChallenge,
 } from '@/types';
 
 let sessionCounter = 1;
@@ -192,5 +194,35 @@ export const createMockCharge = (overrides?: any) => ({
   status: 'succeeded',
   description: 'Navigation Dataset',
   created: Math.floor(Date.now() / 1000),
+  ...overrides,
+});
+
+let challengeCounter = 1;
+
+export const createMockChallenge = (overrides?: Partial<Challenge>): Challenge => ({
+  id: `chl_test_${challengeCounter++}`,
+  user_id: 'usr_test_001',
+  title: `Test Challenge ${challengeCounter}`,
+  description: 'A test challenge description',
+  status: 'active',
+  compensation_amount: 5000,
+  compensation_per: 'dataset',
+  currency: 'USD',
+  deadline: null,
+  constraints: '',
+  conditions: '',
+  tags: ['test'],
+  submission_count: 0,
+  published_at: new Date().toISOString(),
+  closed_at: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  ...overrides,
+});
+
+export const createMockEnrichedChallenge = (overrides?: Partial<EnrichedChallenge>): EnrichedChallenge => ({
+  ...createMockChallenge(overrides),
+  creator_name: overrides?.creator_name ?? 'Test Creator',
+  preview_url: overrides?.preview_url ?? null,
   ...overrides,
 });

--- a/src/test/integration/dashboard-challenges.test.tsx
+++ b/src/test/integration/dashboard-challenges.test.tsx
@@ -19,12 +19,21 @@ const challengeServiceMock = vi.hoisted(() => ({
   deleteDraft: vi.fn(),
 }));
 
+const challengeSubmissionServiceMock = vi.hoisted(() => ({
+  listMineEnriched: vi.fn(),
+  withdraw: vi.fn(),
+}));
+
 vi.mock("@/services/datasetService", () => ({
   listDatasets: datasetServiceMock.listDatasets,
 }));
 
 vi.mock("@/services/challengeService", () => ({
   challengeService: challengeServiceMock,
+}));
+
+vi.mock("@/services/challengeSubmissionService", () => ({
+  challengeSubmissionService: challengeSubmissionServiceMock,
 }));
 
 vi.mock("@/hooks/useAuth", () => ({
@@ -63,6 +72,7 @@ describe("DashboardPage - Challenges Section", () => {
     vi.clearAllMocks();
     datasetServiceMock.listDatasets.mockResolvedValue([]);
     challengeServiceMock.listMine.mockResolvedValue([]);
+    challengeSubmissionServiceMock.listMineEnriched.mockResolvedValue([]);
   });
 
   it("shows challenge count in stats", async () => {

--- a/src/test/integration/dashboard-challenges.test.tsx
+++ b/src/test/integration/dashboard-challenges.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DashboardPage from "@/pages/DashboardPage";
+import { createMockChallenge } from "@/test/helpers/factories";
+
+const datasetServiceMock = vi.hoisted(() => ({
+  listDatasets: vi.fn(),
+}));
+
+const challengeServiceMock = vi.hoisted(() => ({
+  listEnriched: vi.fn(),
+  listMine: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  publish: vi.fn(),
+  setStatus: vi.fn(),
+  deleteDraft: vi.fn(),
+}));
+
+vi.mock("@/services/datasetService", () => ({
+  listDatasets: datasetServiceMock.listDatasets,
+}));
+
+vi.mock("@/services/challengeService", () => ({
+  challengeService: challengeServiceMock,
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: "usr_001", name: "Test User", email: "test@test.com" },
+    login: vi.fn(),
+    logout: vi.fn(),
+    register: vi.fn(),
+    resetPassword: vi.fn(),
+    updatePassword: vi.fn(),
+    refreshUser: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/dashboard"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <Routes>
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/dashboard/challenges/new" element={<div>Create Challenge</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe("DashboardPage - Challenges Section", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    datasetServiceMock.listDatasets.mockResolvedValue([]);
+    challengeServiceMock.listMine.mockResolvedValue([]);
+  });
+
+  it("shows challenge count in stats", async () => {
+    const challenges = [
+      createMockChallenge({ id: "ch_001" }),
+      createMockChallenge({ id: "ch_002" }),
+    ];
+    challengeServiceMock.listMine.mockResolvedValue(challenges);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Challenges").length).toBeGreaterThan(0);
+      expect(screen.getByText("2")).toBeInTheDocument();
+    });
+  });
+
+  it("renders Create Challenge button", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("create-challenge-btn")).toBeInTheDocument();
+    });
+  });
+
+  it("lists user's challenges", async () => {
+    const challenges = [
+      createMockChallenge({ id: "ch_001", title: "Kitchen Task" }),
+    ];
+    challengeServiceMock.listMine.mockResolvedValue(challenges);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Kitchen Task")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no challenges", async () => {
+    challengeServiceMock.listMine.mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no challenges yet/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/integration/dashboard-page.test.tsx
+++ b/src/test/integration/dashboard-page.test.tsx
@@ -11,6 +11,11 @@ const challengeServiceMock = vi.hoisted(() => ({
   listMine: vi.fn(),
 }));
 
+const challengeSubmissionServiceMock = vi.hoisted(() => ({
+  listMineEnriched: vi.fn(),
+  withdraw: vi.fn(),
+}));
+
 vi.mock("@/services/datasetService", () => ({
   listDatasets: datasetServiceMock.listDatasets,
 }));
@@ -19,10 +24,15 @@ vi.mock("@/services/challengeService", () => ({
   challengeService: challengeServiceMock,
 }));
 
+vi.mock("@/services/challengeSubmissionService", () => ({
+  challengeSubmissionService: challengeSubmissionServiceMock,
+}));
+
 describe("DashboardPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     challengeServiceMock.listMine.mockResolvedValue([]);
+    challengeSubmissionServiceMock.listMineEnriched.mockResolvedValue([]);
   });
 
   afterEach(() => {

--- a/src/test/integration/dashboard-page.test.tsx
+++ b/src/test/integration/dashboard-page.test.tsx
@@ -131,6 +131,40 @@ describe("DashboardPage", () => {
     });
   });
 
+  it("still renders datasets when challengeService.listMine rejects", async () => {
+    const mockDatasets = [
+      {
+        id: "ds_001",
+        user_id: "usr_001",
+        display_name: "My Robot Dataset",
+        source_repo_id: null,
+        status: "ready" as const,
+        metadata: null,
+        created_at: new Date().toISOString(),
+        confirmed_at: new Date().toISOString(),
+        file_count: 3,
+        total_size_bytes: 1024,
+        file_paths: [],
+      },
+    ];
+    datasetServiceMock.listDatasets.mockResolvedValue(mockDatasets);
+    challengeServiceMock.listMine.mockRejectedValue(
+      new Error('relation "challenges" does not exist')
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Routes>
+          <Route path="/dashboard" element={<DashboardPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("My Robot Dataset")).toBeInTheDocument();
+    });
+  });
+
   it("displays statistics labels", async () => {
     datasetServiceMock.listDatasets.mockResolvedValue([]);
 

--- a/src/test/integration/dashboard-page.test.tsx
+++ b/src/test/integration/dashboard-page.test.tsx
@@ -7,13 +7,22 @@ const datasetServiceMock = vi.hoisted(() => ({
   listDatasets: vi.fn(),
 }));
 
+const challengeServiceMock = vi.hoisted(() => ({
+  listMine: vi.fn(),
+}));
+
 vi.mock("@/services/datasetService", () => ({
   listDatasets: datasetServiceMock.listDatasets,
+}));
+
+vi.mock("@/services/challengeService", () => ({
+  challengeService: challengeServiceMock,
 }));
 
 describe("DashboardPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    challengeServiceMock.listMine.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -135,7 +144,7 @@ describe("DashboardPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/total data/i)).toBeInTheDocument();
-      expect(screen.getByText(/downloads/i)).toBeInTheDocument();
+      expect(screen.getAllByText(/challenges/i).length).toBeGreaterThan(0);
     });
   });
 });

--- a/src/test/integration/marketplace-challenges.test.tsx
+++ b/src/test/integration/marketplace-challenges.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MarketplacePage from "@/pages/MarketplacePage";
+import { createMockEnrichedChallenge } from "@/test/helpers/factories";
+
+const listingServiceMock = vi.hoisted(() => ({
+  list: vi.fn(),
+  listEnriched: vi.fn(),
+  get: vi.fn(),
+  publish: vi.fn(),
+}));
+
+const challengeServiceMock = vi.hoisted(() => ({
+  listEnriched: vi.fn(),
+  listMine: vi.fn(),
+  get: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  publish: vi.fn(),
+  setStatus: vi.fn(),
+  deleteDraft: vi.fn(),
+}));
+
+vi.mock("@/services/listingService", () => ({
+  listingService: listingServiceMock,
+}));
+
+vi.mock("@/services/challengeService", () => ({
+  challengeService: challengeServiceMock,
+}));
+
+vi.mock("@/services/marketplaceService", () => ({
+  getMarketplaceFileUrls: vi.fn().mockResolvedValue([]),
+}));
+
+const renderPage = (initialEntry = "/marketplace?tab=challenges") =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <Routes>
+        <Route path="/marketplace" element={<MarketplacePage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe("MarketplacePage - Challenges Tab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listingServiceMock.listEnriched.mockResolvedValue([]);
+    challengeServiceMock.listEnriched.mockResolvedValue([]);
+  });
+
+  it("renders Datasets tab by default", async () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tab-datasets")).toBeInTheDocument();
+      expect(screen.getByTestId("tab-challenges")).toBeInTheDocument();
+    });
+  });
+
+  it("switches to Challenges tab on click", async () => {
+    render(
+      <MemoryRouter initialEntries={["/marketplace"]} future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <Routes>
+          <Route path="/marketplace" element={<MarketplacePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const challengesTab = screen.getByTestId("tab-challenges");
+      fireEvent.click(challengesTab);
+    });
+
+    await waitFor(() => {
+      // After clicking Challenges tab, the subtitle text should change
+      expect(screen.getByText(/find challenges requesting datasets/i)).toBeInTheDocument();
+    });
+  });
+
+  it("displays challenge cards in grid", async () => {
+    const mockChallenges = [
+      createMockEnrichedChallenge({ id: "ch_001", title: "Kitchen Manipulation" }),
+      createMockEnrichedChallenge({ id: "ch_002", title: "Warehouse Navigation" }),
+    ];
+    challengeServiceMock.listEnriched.mockResolvedValue(mockChallenges);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Kitchen Manipulation")).toBeInTheDocument();
+      expect(screen.getByText("Warehouse Navigation")).toBeInTheDocument();
+    });
+  });
+
+  it("filters challenges by search query", async () => {
+    const mockChallenges = [
+      createMockEnrichedChallenge({ id: "ch_001", title: "Kitchen Manipulation" }),
+      createMockEnrichedChallenge({ id: "ch_002", title: "Warehouse Navigation" }),
+    ];
+    challengeServiceMock.listEnriched.mockResolvedValue(mockChallenges);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Kitchen Manipulation")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText(/search challenges/i);
+    fireEvent.change(searchInput, { target: { value: "kitchen" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Kitchen Manipulation")).toBeInTheDocument();
+      expect(screen.queryByText("Warehouse Navigation")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no challenges", async () => {
+    challengeServiceMock.listEnriched.mockResolvedValue([]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no challenges yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading skeletons while fetching", async () => {
+    challengeServiceMock.listEnriched.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), 200))
+    );
+
+    renderPage();
+
+    // Loading skeletons should be visible initially
+    await waitFor(() => {
+      expect(challengeServiceMock.listEnriched).toHaveBeenCalled();
+    });
+  });
+
+  it("filters challenges by tag", async () => {
+    const mockChallenges = [
+      createMockEnrichedChallenge({ id: "ch_001", title: "Kitchen Task", tags: ["manipulation"] }),
+      createMockEnrichedChallenge({ id: "ch_002", title: "Nav Task", tags: ["navigation"] }),
+    ];
+    challengeServiceMock.listEnriched.mockResolvedValue(mockChallenges);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Kitchen Task")).toBeInTheDocument();
+      expect(screen.getByText("Nav Task")).toBeInTheDocument();
+    });
+
+    // The tag filter buttons have uppercase tracking-wider styling; find the one that's a filter button
+    // (not inside a card). Use getAllByText and pick the first one which is the filter bar button.
+    const tagButtons = screen.getAllByText("manipulation");
+    fireEvent.click(tagButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Kitchen Task")).toBeInTheDocument();
+      expect(screen.queryByText("Nav Task")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/unit/auth/data-isolation.test.ts
+++ b/src/test/unit/auth/data-isolation.test.ts
@@ -1,0 +1,553 @@
+/**
+ * Data isolation tests — each user must only see, modify, or delete their own data.
+ *
+ * Strategy: mock Supabase to simulate the two possible outcomes for each operation:
+ *   - Owner call  → Supabase returns data / success (RLS allows)
+ *   - Non-owner call → Supabase returns empty / RLS violation error
+ *
+ * We also assert that services with explicit application-level user_id filters
+ * (challengeService.listMine) actually pass the correct user id to the query.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { challengeService } from "@/services/challengeService";
+import {
+  listDatasets,
+  getDataset,
+  deleteDataset,
+} from "@/services/datasetService";
+import { listingService } from "@/services/listingService";
+import { orderService } from "@/services/orderService";
+import { challengeSubmissionService } from "@/services/challengeSubmissionService";
+
+// ---------------------------------------------------------------------------
+// Shared Supabase mock
+// ---------------------------------------------------------------------------
+
+const supabaseMock = vi.hoisted(() => ({
+  supabase: {
+    from: vi.fn(),
+    auth: { getUser: vi.fn() },
+    storage: { from: vi.fn() },
+  },
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: supabaseMock.supabase,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const OWNER_ID = "usr_owner";
+const OTHER_ID = "usr_other";
+
+const mockChallenge = {
+  id: "ch_001",
+  user_id: OWNER_ID,
+  title: "Pick-and-place challenge",
+  status: "active",
+  compensation_amount: 1000,
+  compensation_per: "dataset",
+  currency: "USD",
+  deadline: null,
+  constraints: "",
+  conditions: "",
+  tags: [],
+  submission_count: 0,
+  published_at: new Date().toISOString(),
+  closed_at: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const mockDataset = {
+  id: "ds_001",
+  user_id: OWNER_ID,
+  display_name: "My Robot Dataset",
+  source_repo_id: null,
+  status: "ready" as const,
+  metadata: null,
+  created_at: new Date().toISOString(),
+  confirmed_at: new Date().toISOString(),
+  dataset_files: [],
+};
+
+const mockListing = {
+  id: "ls_001",
+  user_id: OWNER_ID,
+  dataset_id: "ds_001",
+  title: "Pick-and-place scenes",
+  description: "desc",
+  price_amount: 0,
+  currency: "USD",
+  license: "MIT",
+  tags: [],
+  published: true,
+  download_count: 0,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const mockOrder = {
+  id: "ord_001",
+  buyer_id: OWNER_ID,
+  listing_id: "ls_001",
+  amount: 0,
+  currency: "USD",
+  status: "completed",
+  created_at: new Date().toISOString(),
+};
+
+const mockSubmission = {
+  id: "sub_001",
+  challenge_id: "ch_001",
+  submitter_id: OWNER_ID,
+  dataset_id: "ds_001",
+  message: "here you go",
+  status: "pending",
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+// ---------------------------------------------------------------------------
+// Helper — build a chainable Supabase query mock that resolves at the end
+// ---------------------------------------------------------------------------
+
+function chainResolving(result: { data: any; error: any }) {
+  const terminal: any = {};
+  for (const method of [
+    "order",
+    "single",
+    "maybeSingle",
+  ]) {
+    terminal[method] = vi.fn().mockResolvedValue(result);
+  }
+  // eq can chain further or be terminal
+  terminal.eq = vi.fn().mockReturnValue(terminal);
+  terminal.in = vi.fn().mockReturnValue(terminal);
+  return terminal;
+}
+
+// ---------------------------------------------------------------------------
+// challengeService
+// ---------------------------------------------------------------------------
+
+describe("challengeService — data isolation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("listMine passes the authenticated user's id as an explicit eq filter", async () => {
+    supabaseMock.supabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: OWNER_ID } },
+    });
+    const eqMock = vi.fn().mockReturnValue({
+      order: vi.fn().mockResolvedValue({ data: [mockChallenge], error: null }),
+    });
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({ eq: eqMock }),
+    });
+
+    const result = await challengeService.listMine();
+
+    // Explicit application-level user filter — not relying on RLS alone
+    expect(eqMock).toHaveBeenCalledWith("user_id", OWNER_ID);
+    expect(result).toHaveLength(1);
+    expect(result[0].user_id).toBe(OWNER_ID);
+  });
+
+  it("listMine does not return challenges belonging to a different user", async () => {
+    supabaseMock.supabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: OTHER_ID } },
+    });
+    const eqMock = vi.fn().mockReturnValue({
+      // Supabase (or application filter) returns nothing for OTHER_ID
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    });
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({ eq: eqMock }),
+    });
+
+    const result = await challengeService.listMine();
+
+    expect(eqMock).toHaveBeenCalledWith("user_id", OTHER_ID);
+    expect(result).toHaveLength(0);
+    expect(result).not.toContainEqual(expect.objectContaining({ user_id: OWNER_ID }));
+  });
+
+  it("listMine returns empty array for unauthenticated users", async () => {
+    supabaseMock.supabase.auth.getUser.mockResolvedValue({
+      data: { user: null },
+    });
+
+    const result = await challengeService.listMine();
+
+    expect(result).toEqual([]);
+    expect(supabaseMock.supabase.from).not.toHaveBeenCalled();
+  });
+
+  it("update propagates an RLS error when called by a non-owner", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "new row violates row-level security policy" },
+            }),
+          }),
+        }),
+      }),
+    });
+
+    await expect(
+      challengeService.update("ch_001", { title: "Hijacked title" })
+    ).rejects.toThrow();
+  });
+
+  it("deleteDraft throws when the challenge belongs to another user", async () => {
+    // get() returns active challenge owned by OWNER_ID; called as OTHER_ID
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: mockChallenge, // status: "active"
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    // Active challenge → "Only draft challenges can be deleted" before any RLS check
+    await expect(challengeService.deleteDraft("ch_001")).rejects.toThrow(
+      "Only draft challenges can be deleted"
+    );
+  });
+
+  it("setStatus propagates an RLS error when called by a non-owner", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "new row violates row-level security policy" },
+            }),
+          }),
+        }),
+      }),
+    });
+
+    await expect(
+      challengeService.setStatus("ch_001", "inactive")
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// datasetService
+// ---------------------------------------------------------------------------
+
+describe("datasetService — data isolation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("listDatasets returns only the datasets the DB exposes (RLS owner-only)", async () => {
+    // Supabase RLS on datasets table has no public-read policy — owner only.
+    // When authenticated as OWNER_ID, the DB returns their datasets.
+    const terminal = chainResolving({ data: [mockDataset], error: null });
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue(terminal),
+    });
+
+    const result = await listDatasets();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].user_id).toBe(OWNER_ID);
+  });
+
+  it("listDatasets returns empty when RLS filters out another user's datasets", async () => {
+    // Simulates OTHER_ID calling listDatasets — RLS returns nothing
+    const terminal = chainResolving({ data: [], error: null });
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue(terminal),
+    });
+
+    const result = await listDatasets();
+
+    expect(result).toEqual([]);
+  });
+
+  it("getDataset returns null when RLS hides another user's dataset", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
+    });
+
+    const result = await getDataset("ds_001");
+
+    expect(result).toBeNull();
+  });
+
+  it("getDataset returns the dataset when called by the owner", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: mockDataset,
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const result = await getDataset("ds_001");
+
+    expect(result).not.toBeNull();
+    expect(result?.user_id).toBe(OWNER_ID);
+  });
+
+  it("deleteDataset throws when RLS rejects the delete (non-owner)", async () => {
+    const rlsError = { message: "new row violates row-level security policy" };
+    supabaseMock.supabase.from.mockReturnValue({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: rlsError }),
+      }),
+    });
+
+    await expect(deleteDataset("ds_001")).rejects.toThrow();
+  });
+
+  it("deleteDataset resolves when called by the owner", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      delete: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    });
+
+    await expect(deleteDataset("ds_001")).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listingService
+// ---------------------------------------------------------------------------
+
+describe("listingService — data isolation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("update propagates RLS error when called by a non-owner", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "new row violates row-level security policy" },
+            }),
+          }),
+        }),
+      }),
+    });
+
+    await expect(
+      listingService.update("ls_001", { title: "Hijacked" })
+    ).rejects.toThrow();
+  });
+
+  it("update succeeds for the owner", async () => {
+    const updated = { ...mockListing, title: "New title" };
+    supabaseMock.supabase.from.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: updated, error: null }),
+          }),
+        }),
+      }),
+    });
+
+    const result = await listingService.update("ls_001", { title: "New title" });
+
+    expect(result.title).toBe("New title");
+    expect(result.user_id).toBe(OWNER_ID);
+  });
+
+  it("unpublish propagates RLS error when called by a non-owner", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          error: { message: "new row violates row-level security policy" },
+        }),
+      }),
+    });
+
+    await expect(listingService.unpublish("ls_001")).rejects.toThrow();
+  });
+
+  it("unpublish resolves without error for the owner", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    });
+
+    await expect(listingService.unpublish("ls_001")).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orderService
+// ---------------------------------------------------------------------------
+
+describe("orderService — data isolation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("list returns only orders the DB exposes (RLS buyer_read: auth.uid() = buyer_id)", async () => {
+    const terminal = chainResolving({ data: [mockOrder], error: null });
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue(terminal),
+    });
+
+    const result = await orderService.list();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].buyer_id).toBe(OWNER_ID);
+  });
+
+  it("list returns empty when RLS hides another user's orders", async () => {
+    const terminal = chainResolving({ data: [], error: null });
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue(terminal),
+    });
+
+    const result = await orderService.list();
+
+    expect(result).toEqual([]);
+  });
+
+  it("create sets buyer_id to the authenticated user's id", async () => {
+    supabaseMock.supabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: OWNER_ID } },
+    });
+    const insertMock = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: mockOrder, error: null }),
+      }),
+    });
+    supabaseMock.supabase.from.mockReturnValue({ insert: insertMock });
+
+    const result = await orderService.create("ls_001", 0);
+
+    const insertedPayload = insertMock.mock.calls[0][0];
+    expect(insertedPayload.buyer_id).toBe(OWNER_ID);
+    expect(result.buyer_id).toBe(OWNER_ID);
+  });
+
+  it("create throws when not authenticated", async () => {
+    supabaseMock.supabase.auth.getUser.mockResolvedValue({
+      data: { user: null },
+    });
+
+    await expect(orderService.create("ls_001", 0)).rejects.toThrow(
+      "Not authenticated"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// challengeSubmissionService
+// ---------------------------------------------------------------------------
+
+describe("challengeSubmissionService — data isolation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("submit sets submitter_id to the authenticated user's id", async () => {
+    supabaseMock.supabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: OWNER_ID } },
+    });
+    const insertMock = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: mockSubmission,
+          error: null,
+        }),
+      }),
+    });
+    supabaseMock.supabase.from.mockReturnValue({ insert: insertMock });
+
+    await challengeSubmissionService.submit({
+      challenge_id: "ch_001",
+      dataset_id: "ds_001",
+      message: "here you go",
+    });
+
+    const payload = insertMock.mock.calls[0][0];
+    expect(payload.submitter_id).toBe(OWNER_ID);
+  });
+
+  it("submit throws when not authenticated", async () => {
+    supabaseMock.supabase.auth.getUser.mockResolvedValue({
+      data: { user: null },
+    });
+
+    await expect(
+      challengeSubmissionService.submit({
+        challenge_id: "ch_001",
+        dataset_id: "ds_001",
+        message: "attempt",
+      })
+    ).rejects.toThrow("Not authenticated");
+  });
+
+  it("listForChallenge returns only submissions the DB exposes (RLS: owner sees all, submitter sees own)", async () => {
+    const terminal = chainResolving({ data: [mockSubmission], error: null });
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue(terminal),
+    });
+
+    const result = await challengeSubmissionService.listForChallenge("ch_001");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].challenge_id).toBe("ch_001");
+  });
+
+  it("listForChallenge returns empty when RLS hides submissions from unrelated user", async () => {
+    const terminal = chainResolving({ data: [], error: null });
+    supabaseMock.supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnValue(terminal),
+    });
+
+    const result = await challengeSubmissionService.listForChallenge("ch_001");
+
+    expect(result).toEqual([]);
+  });
+
+  it("updateStatus propagates RLS error when called by a non-owner of the challenge", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          error: { message: "new row violates row-level security policy" },
+        }),
+      }),
+    });
+
+    await expect(
+      challengeSubmissionService.updateStatus("sub_001", "accepted")
+    ).rejects.toThrow();
+  });
+
+  it("updateStatus resolves when called by the challenge owner", async () => {
+    supabaseMock.supabase.from.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    });
+
+    await expect(
+      challengeSubmissionService.updateStatus("sub_001", "accepted")
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/test/unit/components/ChallengeCard.test.tsx
+++ b/src/test/unit/components/ChallengeCard.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import ChallengeCard from "@/components/ChallengeCard";
+import type { EnrichedChallenge } from "@/types";
+
+const baseChallenge: EnrichedChallenge = {
+  id: "ch_001",
+  user_id: "usr_001",
+  title: "Kitchen object manipulation",
+  description: "Need datasets of picking and placing kitchen objects",
+  status: "active",
+  compensation_amount: 5000,
+  compensation_per: "dataset",
+  currency: "USD",
+  deadline: null,
+  constraints: "",
+  conditions: "",
+  tags: ["manipulation", "kitchen", "UR5"],
+  submission_count: 3,
+  published_at: new Date().toISOString(),
+  closed_at: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+  creator_name: "Juan",
+  preview_url: null,
+};
+
+const renderCard = (overrides: Partial<EnrichedChallenge> = {}) =>
+  render(
+    <MemoryRouter>
+      <ChallengeCard challenge={{ ...baseChallenge, ...overrides }} />
+    </MemoryRouter>
+  );
+
+describe("ChallengeCard", () => {
+  it("renders title and description", () => {
+    renderCard();
+    expect(screen.getByText("Kitchen object manipulation")).toBeInTheDocument();
+    expect(screen.getByText(/picking and placing/)).toBeInTheDocument();
+  });
+
+  it("shows compensation badge with per-dataset label", () => {
+    renderCard();
+    expect(screen.getByText("$50.00")).toBeInTheDocument();
+    expect(screen.getByText("/dataset")).toBeInTheDocument();
+  });
+
+  it("shows lump sum label for challenge compensation", () => {
+    renderCard({ compensation_per: "challenge", compensation_amount: 10000 });
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    expect(screen.getByText("total")).toBeInTheDocument();
+  });
+
+  it("shows Volunteer when compensation is 0", () => {
+    renderCard({ compensation_amount: 0 });
+    expect(screen.getByText("Volunteer")).toBeInTheDocument();
+  });
+
+  it("shows 'No deadline' when deadline is null", () => {
+    renderCard();
+    expect(screen.getByText("No deadline")).toBeInTheDocument();
+  });
+
+  it("shows deadline with days remaining for future date", () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 10);
+    renderCard({ deadline: future.toISOString() });
+    expect(screen.getByText("10d left")).toBeInTheDocument();
+  });
+
+  it("shows 'Deadline passed' for past date", () => {
+    const past = new Date();
+    past.setDate(past.getDate() - 5);
+    renderCard({ deadline: past.toISOString() });
+    expect(screen.getByText("Deadline passed")).toBeInTheDocument();
+  });
+
+  it("shows submission count", () => {
+    renderCard();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders tags", () => {
+    renderCard();
+    expect(screen.getByText("manipulation")).toBeInTheDocument();
+    expect(screen.getByText("kitchen")).toBeInTheDocument();
+    expect(screen.getByText("UR5")).toBeInTheDocument();
+  });
+
+  it("links to challenge detail page", () => {
+    renderCard();
+    const link = screen.getByTestId("challenge-card");
+    expect(link.closest("a")).toHaveAttribute("href", "/marketplace/challenges/ch_001");
+  });
+
+  it("shows creator name", () => {
+    renderCard();
+    expect(screen.getByText("Juan")).toBeInTheDocument();
+  });
+
+  it("shows fallback icon when no preview", () => {
+    const { container } = renderCard();
+    // Target icon is rendered as fallback
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+});

--- a/src/test/unit/components/ChallengeListCard.test.tsx
+++ b/src/test/unit/components/ChallengeListCard.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import ChallengeListCard from "@/components/ChallengeListCard";
+import type { Challenge } from "@/types";
+
+const baseChallenge: Challenge = {
+  id: "ch_001",
+  user_id: "usr_001",
+  title: "Kitchen manipulation",
+  description: "Test",
+  status: "draft",
+  compensation_amount: 5000,
+  compensation_per: "dataset",
+  currency: "USD",
+  deadline: null,
+  constraints: "",
+  conditions: "",
+  tags: [],
+  submission_count: 0,
+  published_at: null,
+  closed_at: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const renderCard = (overrides: Partial<Challenge> = {}, handlers = {}) =>
+  render(
+    <MemoryRouter>
+      <ChallengeListCard
+        challenge={{ ...baseChallenge, ...overrides }}
+        onPublish={vi.fn()}
+        onToggleStatus={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+        {...handlers}
+      />
+    </MemoryRouter>
+  );
+
+describe("ChallengeListCard", () => {
+  it("renders title and status badge", () => {
+    renderCard();
+    expect(screen.getByText("Kitchen manipulation")).toBeInTheDocument();
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+  });
+
+  it("shows edit link", () => {
+    renderCard();
+    expect(screen.getByTestId("edit-btn")).toBeInTheDocument();
+  });
+
+  it("shows delete button only for draft", () => {
+    renderCard({ status: "draft" });
+    expect(screen.getByTestId("delete-btn")).toBeInTheDocument();
+  });
+
+  it("hides delete button for active", () => {
+    renderCard({ status: "active" });
+    expect(screen.queryByTestId("delete-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows publish button for draft", () => {
+    renderCard({ status: "draft" });
+    expect(screen.getByTestId("publish-btn")).toBeInTheDocument();
+  });
+
+  it("shows deactivate button for active", () => {
+    renderCard({ status: "active" });
+    expect(screen.getByTestId("deactivate-btn")).toBeInTheDocument();
+  });
+
+  it("shows activate button for inactive", () => {
+    renderCard({ status: "inactive" });
+    expect(screen.getByTestId("activate-btn")).toBeInTheDocument();
+  });
+
+  it("hides actions for closed", () => {
+    renderCard({ status: "closed" });
+    expect(screen.queryByTestId("publish-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("edit-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deactivate-btn")).not.toBeInTheDocument();
+  });
+
+  it("shows compensation info", () => {
+    renderCard();
+    expect(screen.getByText(/\$50\.00/)).toBeInTheDocument();
+  });
+
+  it("shows submission count", () => {
+    renderCard({ submission_count: 5 });
+    expect(screen.getByText("5 submissions")).toBeInTheDocument();
+  });
+
+  it("calls onPublish when publish clicked", () => {
+    const onPublish = vi.fn();
+    renderCard({ status: "draft" }, { onPublish });
+    fireEvent.click(screen.getByTestId("publish-btn"));
+    expect(onPublish).toHaveBeenCalledWith("ch_001");
+  });
+
+  it("calls onDelete when delete clicked", () => {
+    const onDelete = vi.fn();
+    renderCard({ status: "draft" }, { onDelete });
+    fireEvent.click(screen.getByTestId("delete-btn"));
+    expect(onDelete).toHaveBeenCalledWith("ch_001");
+  });
+});

--- a/src/test/unit/components/ChallengeStatusBadge.test.tsx
+++ b/src/test/unit/components/ChallengeStatusBadge.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ChallengeStatusBadge from "@/components/ChallengeStatusBadge";
+
+describe("ChallengeStatusBadge", () => {
+  it("renders 'Draft' for draft status", () => {
+    render(<ChallengeStatusBadge status="draft" />);
+    expect(screen.getByText("Draft")).toBeInTheDocument();
+  });
+
+  it("renders 'Active' for active status", () => {
+    render(<ChallengeStatusBadge status="active" />);
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("renders 'Inactive' for inactive status", () => {
+    render(<ChallengeStatusBadge status="inactive" />);
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+  });
+
+  it("renders 'Closed' for closed status", () => {
+    render(<ChallengeStatusBadge status="closed" />);
+    expect(screen.getByText("Closed")).toBeInTheDocument();
+  });
+
+  it("applies green styling for active", () => {
+    render(<ChallengeStatusBadge status="active" />);
+    const badge = screen.getByTestId("challenge-status-badge");
+    expect(badge.className).toContain("green");
+  });
+
+  it("applies red styling for closed", () => {
+    render(<ChallengeStatusBadge status="closed" />);
+    const badge = screen.getByTestId("challenge-status-badge");
+    expect(badge.className).toContain("red");
+  });
+
+  it("applies yellow styling for inactive", () => {
+    render(<ChallengeStatusBadge status="inactive" />);
+    const badge = screen.getByTestId("challenge-status-badge");
+    expect(badge.className).toContain("yellow");
+  });
+});

--- a/src/test/unit/services/challengeMediaService.test.ts
+++ b/src/test/unit/services/challengeMediaService.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { challengeMediaService } from "@/services/challengeMediaService";
+
+const supabaseMock = vi.hoisted(() => ({
+  supabase: {
+    from: vi.fn(),
+    storage: {
+      from: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: supabaseMock.supabase,
+}));
+
+const mockMedia = {
+  id: "med_001",
+  challenge_id: "ch_001",
+  user_id: "usr_001",
+  storage_path: "usr_001/ch_001/abc123-test.mp4",
+  file_name: "test.mp4",
+  content_type: "video/mp4",
+  size_bytes: 1024000,
+  sort_order: 0,
+  created_at: new Date().toISOString(),
+};
+
+describe("challengeMediaService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("list", () => {
+    it("returns media ordered by sort_order", async () => {
+      const media2 = { ...mockMedia, id: "med_002", sort_order: 1 };
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: [mockMedia, media2],
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeMediaService.list("ch_001");
+      expect(result).toHaveLength(2);
+      expect(result[0].sort_order).toBe(0);
+    });
+
+    it("returns empty array for challenge with no media", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeMediaService.list("ch_999");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getSignedUrl", () => {
+    it("returns signed URL string", async () => {
+      supabaseMock.supabase.storage.from.mockReturnValue({
+        createSignedUrl: vi.fn().mockResolvedValue({
+          data: { signedUrl: "https://example.com/signed-url" },
+          error: null,
+        }),
+      });
+
+      const url = await challengeMediaService.getSignedUrl("usr_001/ch_001/test.mp4");
+      expect(url).toBe("https://example.com/signed-url");
+    });
+  });
+
+  describe("delete", () => {
+    it("removes storage file and database record", async () => {
+      const removeMock = vi.fn().mockResolvedValue({ error: null });
+      supabaseMock.supabase.storage.from.mockReturnValue({
+        remove: removeMock,
+      });
+      supabaseMock.supabase.from.mockReturnValue({
+        delete: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      });
+
+      await challengeMediaService.delete("med_001", "usr_001/ch_001/test.mp4");
+      expect(removeMock).toHaveBeenCalledWith(["usr_001/ch_001/test.mp4"]);
+    });
+  });
+
+  describe("upload", () => {
+    it("uploads file and creates record", async () => {
+      const file = new File(["test"], "test.mp4", { type: "video/mp4" });
+      supabaseMock.supabase.storage.from.mockReturnValue({
+        upload: vi.fn().mockResolvedValue({ error: null }),
+      });
+      supabaseMock.supabase.from.mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: mockMedia,
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeMediaService.upload("ch_001", "usr_001", file);
+      expect(result).toBeDefined();
+      expect(result.file_name).toBe("test.mp4");
+    });
+  });
+
+  describe("reorder", () => {
+    it("updates sort_order for given items", async () => {
+      const updateMock = vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      });
+      supabaseMock.supabase.from.mockReturnValue({
+        update: updateMock,
+      });
+
+      await challengeMediaService.reorder([
+        { id: "med_001", sort_order: 1 },
+        { id: "med_002", sort_order: 0 },
+      ]);
+
+      expect(updateMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/test/unit/services/challengeService.test.ts
+++ b/src/test/unit/services/challengeService.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { challengeService } from "@/services/challengeService";
+
+const supabaseMock = vi.hoisted(() => ({
+  supabase: {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(),
+    },
+    storage: {
+      from: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: supabaseMock.supabase,
+}));
+
+const mockChallenge = {
+  id: "ch_001",
+  user_id: "usr_001",
+  title: "Kitchen manipulation dataset",
+  description: "Need datasets of kitchen object manipulation",
+  status: "active",
+  compensation_amount: 5000,
+  compensation_per: "dataset",
+  currency: "USD",
+  deadline: null,
+  constraints: "Must use UR5 robot",
+  conditions: "At least 100 episodes",
+  tags: ["manipulation", "kitchen"],
+  submission_count: 3,
+  published_at: new Date().toISOString(),
+  closed_at: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+const mockDraftChallenge = {
+  ...mockChallenge,
+  id: "ch_002",
+  status: "draft",
+  published_at: null,
+};
+
+describe("challengeService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listMine", () => {
+    it("returns user's challenges of all statuses", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({
+            data: [mockChallenge, mockDraftChallenge],
+            error: null,
+          }),
+        }),
+      });
+
+      const result = await challengeService.listMine();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(2);
+    });
+
+    it("returns empty array when no challenges", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({
+            data: [],
+            error: null,
+          }),
+        }),
+      });
+
+      const result = await challengeService.listMine();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("get", () => {
+    it("returns challenge by id", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: mockChallenge,
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeService.get("ch_001");
+      expect(result).toBeDefined();
+      expect(result?.id).toBe("ch_001");
+      expect(result?.title).toBe("Kitchen manipulation dataset");
+    });
+
+    it("returns undefined for non-existent id", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeService.get("nonexistent");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("create", () => {
+    it("creates challenge with draft status", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "usr_001" } },
+      });
+      supabaseMock.supabase.from.mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: mockDraftChallenge,
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeService.create({
+        title: "Test challenge",
+        description: "Test description",
+        compensation_amount: 0,
+        compensation_per: "dataset",
+        currency: "USD",
+        deadline: null,
+        constraints: "",
+        conditions: "",
+        tags: [],
+      });
+
+      expect(result).toBeDefined();
+      expect(result.status).toBe("draft");
+    });
+
+    it("throws when not authenticated", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+      });
+
+      await expect(challengeService.create({
+        title: "Test",
+        description: "",
+        compensation_amount: 0,
+        compensation_per: "dataset",
+        currency: "USD",
+        deadline: null,
+        constraints: "",
+        conditions: "",
+        tags: [],
+      })).rejects.toThrow("Not authenticated");
+    });
+  });
+
+  describe("update", () => {
+    it("updates specified fields", async () => {
+      const updated = { ...mockChallenge, title: "Updated title" };
+      supabaseMock.supabase.from.mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: updated,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeService.update("ch_001", { title: "Updated title" });
+      expect(result.title).toBe("Updated title");
+    });
+  });
+
+  describe("publish", () => {
+    it("sets status to active", async () => {
+      const published = { ...mockDraftChallenge, status: "active" };
+      supabaseMock.supabase.from.mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: published,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeService.publish("ch_002");
+      expect(result.status).toBe("active");
+    });
+  });
+
+  describe("setStatus", () => {
+    it("sets to inactive", async () => {
+      const inactive = { ...mockChallenge, status: "inactive" };
+      supabaseMock.supabase.from.mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: inactive,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeService.setStatus("ch_001", "inactive");
+      expect(result.status).toBe("inactive");
+    });
+
+    it("sets to closed", async () => {
+      const closed = { ...mockChallenge, status: "closed", closed_at: new Date().toISOString() };
+      supabaseMock.supabase.from.mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: closed,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeService.setStatus("ch_001", "closed");
+      expect(result.status).toBe("closed");
+    });
+  });
+
+  describe("deleteDraft", () => {
+    it("deletes draft challenge", async () => {
+      // Mock get() for the draft check
+      supabaseMock.supabase.from.mockImplementation((table: string) => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: mockDraftChallenge,
+              error: null,
+            }),
+          }),
+        }),
+        delete: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      }));
+
+      await expect(challengeService.deleteDraft("ch_002")).resolves.toBeUndefined();
+    });
+
+    it("rejects deletion of non-draft challenges", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: mockChallenge, // status: "active"
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      await expect(challengeService.deleteDraft("ch_001")).rejects.toThrow(
+        "Only draft challenges can be deleted"
+      );
+    });
+  });
+});

--- a/src/test/unit/services/challengeService.test.ts
+++ b/src/test/unit/services/challengeService.test.ts
@@ -50,27 +50,63 @@ describe("challengeService", () => {
   });
 
   describe("listMine", () => {
-    it("returns user's challenges of all statuses", async () => {
-      supabaseMock.supabase.from.mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          order: vi.fn().mockResolvedValue({
-            data: [mockChallenge, mockDraftChallenge],
-            error: null,
-          }),
+    it("filters by the authenticated user's id", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "usr_001" } },
+      });
+      const eqMock = vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({
+          data: [mockChallenge, mockDraftChallenge],
+          error: null,
         }),
+      });
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({ eq: eqMock }),
       });
 
       const result = await challengeService.listMine();
-      expect(Array.isArray(result)).toBe(true);
+      expect(eqMock).toHaveBeenCalledWith("user_id", "usr_001");
       expect(result).toHaveLength(2);
     });
 
-    it("returns empty array when no challenges", async () => {
+    it("does not return challenges owned by other users", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "usr_other" } },
+      });
+      const otherUserChallenge = { ...mockChallenge, user_id: "usr_001" };
+      const eqMock = vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({
+          data: [],
+          error: null,
+        }),
+      });
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({ eq: eqMock }),
+      });
+
+      const result = await challengeService.listMine();
+      expect(eqMock).toHaveBeenCalledWith("user_id", "usr_other");
+      expect(result).toHaveLength(0);
+      expect(result).not.toContainEqual(otherUserChallenge);
+    });
+
+    it("returns empty array when unauthenticated", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+      });
+
+      const result = await challengeService.listMine();
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when user has no challenges", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "usr_001" } },
+      });
       supabaseMock.supabase.from.mockReturnValue({
         select: vi.fn().mockReturnValue({
-          order: vi.fn().mockResolvedValue({
-            data: [],
-            error: null,
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
           }),
         }),
       });

--- a/src/test/unit/services/challengeSubmissionService.test.ts
+++ b/src/test/unit/services/challengeSubmissionService.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { challengeSubmissionService } from "@/services/challengeSubmissionService";
+
+const supabaseMock = vi.hoisted(() => ({
+  supabase: {
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: supabaseMock.supabase,
+}));
+
+const mockSubmission = {
+  id: "sub_001",
+  challenge_id: "ch_001",
+  dataset_id: "ds_001",
+  submitter_id: "usr_002",
+  message: "This dataset matches your requirements",
+  status: "pending",
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+describe("challengeSubmissionService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("submit", () => {
+    it("creates submission with pending status", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "usr_002" } },
+      });
+      supabaseMock.supabase.from.mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: mockSubmission,
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeSubmissionService.submit({
+        challenge_id: "ch_001",
+        dataset_id: "ds_001",
+        message: "This dataset matches your requirements",
+      });
+
+      expect(result).toBeDefined();
+      expect(result.status).toBe("pending");
+    });
+
+    it("throws when not authenticated", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+      });
+
+      await expect(challengeSubmissionService.submit({
+        challenge_id: "ch_001",
+        dataset_id: "ds_001",
+        message: "",
+      })).rejects.toThrow("Not authenticated");
+    });
+  });
+
+  describe("listForChallenge", () => {
+    it("returns submissions for a given challenge", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: [mockSubmission],
+              error: null,
+            }),
+          }),
+        }),
+      });
+
+      const result = await challengeSubmissionService.listForChallenge("ch_001");
+      expect(result).toHaveLength(1);
+      expect(result[0].challenge_id).toBe("ch_001");
+    });
+  });
+
+  describe("listMine", () => {
+    it("returns user's own submissions", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({
+            data: [mockSubmission],
+            error: null,
+          }),
+        }),
+      });
+
+      const result = await challengeSubmissionService.listMine();
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("updateStatus", () => {
+    it("updates to accepted", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      });
+
+      await expect(
+        challengeSubmissionService.updateStatus("sub_001", "accepted")
+      ).resolves.toBeUndefined();
+    });
+
+    it("updates to rejected", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      });
+
+      await expect(
+        challengeSubmissionService.updateStatus("sub_001", "rejected")
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/test/unit/services/challengeSubmissionService.test.ts
+++ b/src/test/unit/services/challengeSubmissionService.test.ts
@@ -90,17 +90,33 @@ describe("challengeSubmissionService", () => {
 
   describe("listMine", () => {
     it("returns user's own submissions", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: { id: "usr_002" } },
+      });
       supabaseMock.supabase.from.mockReturnValue({
         select: vi.fn().mockReturnValue({
-          order: vi.fn().mockResolvedValue({
-            data: [mockSubmission],
-            error: null,
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: [mockSubmission],
+              error: null,
+            }),
           }),
         }),
       });
 
       const result = await challengeSubmissionService.listMine();
       expect(result).toHaveLength(1);
+    });
+
+    it("returns empty array when not authenticated", async () => {
+      supabaseMock.supabase.auth.getUser.mockResolvedValue({
+        data: { user: null },
+      });
+
+      const result = await challengeSubmissionService.listMine();
+
+      expect(result).toEqual([]);
+      expect(supabaseMock.supabase.from).not.toHaveBeenCalled();
     });
   });
 
@@ -127,6 +143,57 @@ describe("challengeSubmissionService", () => {
       await expect(
         challengeSubmissionService.updateStatus("sub_001", "rejected")
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("withdraw", () => {
+    it("deletes submission by id", async () => {
+      supabaseMock.supabase.from.mockReturnValue({
+        delete: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      });
+
+      await expect(
+        challengeSubmissionService.withdraw("sub_001")
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("listMineEnriched", () => {
+    it("returns submissions enriched with challenge and dataset metadata", async () => {
+      vi.spyOn(challengeSubmissionService, "listMine").mockResolvedValue([mockSubmission as any]);
+
+      supabaseMock.supabase.from
+        .mockImplementationOnce(() => ({
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({
+              data: [{
+                id: "ch_001",
+                title: "Challenge title",
+                compensation_amount: 1000,
+                compensation_per: "dataset",
+                currency: "USD",
+                status: "active",
+              }],
+              error: null,
+            }),
+          }),
+        }))
+        .mockImplementationOnce(() => ({
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({
+              data: [{ id: "ds_001", display_name: "Dataset 1" }],
+              error: null,
+            }),
+          }),
+        }));
+
+      const result = await challengeSubmissionService.listMineEnriched();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].dataset_display_name).toBe("Dataset 1");
+      expect(result[0].challenge?.title).toBe("Challenge title");
     });
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -168,6 +168,19 @@ export interface ChallengeSubmission {
   updated_at: string;
 }
 
+export interface ChallengeSubmissionEnriched extends ChallengeSubmission {
+  dataset_display_name: string | null;
+  submitter_name: string | null;
+}
+
+export interface ParticipantSubmissionItem extends ChallengeSubmission {
+  challenge: Pick<
+    Challenge,
+    "id" | "title" | "compensation_amount" | "compensation_per" | "currency" | "status"
+  > | null;
+  dataset_display_name: string | null;
+}
+
 export interface EnrichedChallenge extends Challenge {
   creator_name: string;
   preview_url: string | null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,3 +124,51 @@ export interface DatasetFile {
   upload_status: "pending" | "uploaded";
   created_at: string;
 }
+
+export interface Challenge {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  status: "draft" | "active" | "inactive" | "closed";
+  compensation_amount: number;
+  compensation_per: "dataset" | "challenge";
+  currency: string;
+  deadline: string | null;
+  constraints: string;
+  conditions: string;
+  tags: string[];
+  submission_count: number;
+  published_at: string | null;
+  closed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChallengeMedia {
+  id: string;
+  challenge_id: string;
+  user_id: string;
+  storage_path: string;
+  file_name: string;
+  content_type: string;
+  size_bytes: number | null;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface ChallengeSubmission {
+  id: string;
+  challenge_id: string;
+  dataset_id: string;
+  submitter_id: string;
+  message: string;
+  status: "pending" | "accepted" | "rejected";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EnrichedChallenge extends Challenge {
+  creator_name: string;
+  preview_url: string | null;
+}

--- a/supabase/functions/dataset-read-urls/index.ts
+++ b/supabase/functions/dataset-read-urls/index.ts
@@ -73,7 +73,7 @@ Deno.serve(async (req) => {
     return jsonError("Missing or invalid 'dataset_id'", 400);
   }
 
-  // --- 3. Verify dataset ownership ---
+  // --- 3. Verify dataset access ---
   const adminClient = createClient(supabaseUrl, serviceRoleKey);
 
   const { data: dataset, error: dsError } = await adminClient
@@ -89,8 +89,51 @@ Deno.serve(async (req) => {
   if (!dataset) {
     return jsonError("Dataset not found", 404);
   }
-  if (dataset.user_id !== user.id) {
-    return jsonError("Access denied", 403);
+
+  const isDatasetOwner = dataset.user_id === user.id;
+  if (!isDatasetOwner) {
+    const { data: submitterSubmission, error: submitterError } = await adminClient
+      .from("challenge_submissions")
+      .select("id")
+      .eq("dataset_id", body.dataset_id)
+      .eq("submitter_id", user.id)
+      .limit(1)
+      .maybeSingle();
+    if (submitterError) {
+      console.error("Submission access (submitter) error:", submitterError);
+      return jsonError("Internal error", 500);
+    }
+
+    const { data: acceptedRows, error: acceptedRowsError } = await adminClient
+      .from("challenge_submissions")
+      .select("challenge_id")
+      .eq("dataset_id", body.dataset_id)
+      .eq("status", "accepted");
+    if (acceptedRowsError) {
+      console.error("Submission access (accepted rows) error:", acceptedRowsError);
+      return jsonError("Internal error", 500);
+    }
+
+    let isAcceptedChallengeOwner = false;
+    const acceptedChallengeIds = [...new Set((acceptedRows ?? []).map((r) => r.challenge_id))];
+    if (acceptedChallengeIds.length > 0) {
+      const { data: ownerChallenge, error: ownerError } = await adminClient
+        .from("challenges")
+        .select("id")
+        .eq("user_id", user.id)
+        .in("id", acceptedChallengeIds)
+        .limit(1)
+        .maybeSingle();
+      if (ownerError) {
+        console.error("Submission access (challenge owner) error:", ownerError);
+        return jsonError("Internal error", 500);
+      }
+      isAcceptedChallengeOwner = !!ownerChallenge;
+    }
+
+    if (!submitterSubmission && !isAcceptedChallengeOwner) {
+      return jsonError("Access denied", 403);
+    }
   }
 
   // --- 4. Fetch file records ---

--- a/supabase/functions/get-dataset-manifest/index.ts
+++ b/supabase/functions/get-dataset-manifest/index.ts
@@ -54,7 +54,7 @@ async function handleManifest(datasetId: string, jwt: string) {
 
   const adminClient = createClient(supabaseUrl, serviceRoleKey);
 
-  // Fetch dataset & verify ownership
+  // Fetch dataset and resolve access rules
   const { data: dataset, error: dsError } = await adminClient
     .from("datasets")
     .select("id, user_id")
@@ -68,8 +68,50 @@ async function handleManifest(datasetId: string, jwt: string) {
   if (!dataset) {
     return jsonError("Dataset not found", 404);
   }
-  if (dataset.user_id !== user.id) {
-    return jsonError("Access denied", 403);
+
+  const isDatasetOwner = dataset.user_id === user.id;
+  if (!isDatasetOwner) {
+    const { data: submitterSubmission, error: submitterError } = await adminClient
+      .from("challenge_submissions")
+      .select("id")
+      .eq("dataset_id", datasetId)
+      .eq("submitter_id", user.id)
+      .limit(1)
+      .maybeSingle();
+    if (submitterError) {
+      console.error("Submission access (submitter) error:", submitterError);
+      return jsonError("Internal error", 500);
+    }
+
+    let isChallengeOwner = false;
+    const { data: ownerChallengeRows, error: ownerChallengeError } = await adminClient
+      .from("challenge_submissions")
+      .select("challenge_id")
+      .eq("dataset_id", datasetId);
+    if (ownerChallengeError) {
+      console.error("Submission access (challenge rows) error:", ownerChallengeError);
+      return jsonError("Internal error", 500);
+    }
+
+    const challengeIds = [...new Set((ownerChallengeRows ?? []).map((r) => r.challenge_id))];
+    if (challengeIds.length > 0) {
+      const { data: ownerChallenge, error: ownerError } = await adminClient
+        .from("challenges")
+        .select("id")
+        .eq("user_id", user.id)
+        .in("id", challengeIds)
+        .limit(1)
+        .maybeSingle();
+      if (ownerError) {
+        console.error("Submission access (challenge owner) error:", ownerError);
+        return jsonError("Internal error", 500);
+      }
+      isChallengeOwner = !!ownerChallenge;
+    }
+
+    if (!submitterSubmission && !isChallengeOwner) {
+      return jsonError("Access denied", 403);
+    }
   }
 
   // Fetch uploaded files

--- a/supabase/migrations/20260409120000_challenges_feature.sql
+++ b/supabase/migrations/20260409120000_challenges_feature.sql
@@ -1,0 +1,218 @@
+-- ============================================================
+-- Challenges Feature: tables, triggers, indexes, RLS, storage
+-- ============================================================
+
+-- 1. challenges table
+CREATE TABLE public.challenges (
+  id                  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             uuid        NOT NULL,
+  title               text        NOT NULL CHECK (length(trim(title)) > 0),
+  description         text        NOT NULL DEFAULT '',
+  status              text        NOT NULL DEFAULT 'draft'
+                                  CHECK (status IN ('draft','active','inactive','closed')),
+  compensation_amount integer     NOT NULL DEFAULT 0 CHECK (compensation_amount >= 0),
+  compensation_per    text        NOT NULL DEFAULT 'dataset'
+                                  CHECK (compensation_per IN ('dataset','challenge')),
+  currency            text        NOT NULL DEFAULT 'USD'
+                                  CHECK (currency IN ('USD','KRW')),
+  deadline            timestamptz,
+  constraints         text        NOT NULL DEFAULT '',
+  conditions          text        NOT NULL DEFAULT '',
+  tags                text[]      NOT NULL DEFAULT '{}',
+  submission_count    integer     NOT NULL DEFAULT 0,
+  published_at        timestamptz,
+  closed_at           timestamptz,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_challenges_user     ON public.challenges (user_id, created_at DESC);
+CREATE INDEX idx_challenges_active   ON public.challenges (created_at DESC) WHERE status = 'active';
+CREATE INDEX idx_challenges_deadline  ON public.challenges (deadline) WHERE deadline IS NOT NULL;
+CREATE INDEX idx_challenges_tags     ON public.challenges USING GIN (tags);
+
+ALTER TABLE public.challenges ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "challenges_owner_crud" ON public.challenges FOR ALL
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "challenges_public_read_active" ON public.challenges FOR SELECT
+  TO anon, authenticated
+  USING (status = 'active');
+
+-- Status transition trigger
+CREATE OR REPLACE FUNCTION public.validate_challenge_status_transition()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF OLD.status = NEW.status THEN
+    NEW.updated_at := now();
+    RETURN NEW;
+  END IF;
+
+  IF NOT (
+    (OLD.status = 'draft'    AND NEW.status IN ('active','closed')) OR
+    (OLD.status = 'active'   AND NEW.status IN ('inactive','closed')) OR
+    (OLD.status = 'inactive' AND NEW.status IN ('active','closed'))
+  ) THEN
+    RAISE EXCEPTION 'Invalid challenge status transition from % to %', OLD.status, NEW.status;
+  END IF;
+
+  IF NEW.status = 'active' AND OLD.status = 'draft' THEN
+    NEW.published_at := now();
+  END IF;
+  IF NEW.status = 'closed' THEN
+    NEW.closed_at := now();
+  END IF;
+  NEW.updated_at := now();
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_challenge_status
+  BEFORE UPDATE ON public.challenges
+  FOR EACH ROW EXECUTE FUNCTION public.validate_challenge_status_transition();
+
+-- 2. challenge_media table
+CREATE TABLE public.challenge_media (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  challenge_id  uuid        NOT NULL REFERENCES public.challenges(id) ON DELETE CASCADE,
+  user_id       uuid        NOT NULL,
+  storage_path  text        NOT NULL,
+  file_name     text        NOT NULL,
+  content_type  text        NOT NULL,
+  size_bytes    bigint,
+  sort_order    integer     NOT NULL DEFAULT 0,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_challenge_media_order ON public.challenge_media (challenge_id, sort_order);
+
+ALTER TABLE public.challenge_media ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "challenge_media_owner_crud" ON public.challenge_media FOR ALL
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "challenge_media_public_read" ON public.challenge_media FOR SELECT
+  TO anon, authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.challenges c
+    WHERE c.id = challenge_id AND c.status = 'active'
+  ));
+
+-- 3. challenge_submissions table
+CREATE TABLE public.challenge_submissions (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  challenge_id  uuid        NOT NULL REFERENCES public.challenges(id) ON DELETE CASCADE,
+  dataset_id    uuid        NOT NULL REFERENCES public.datasets(id),
+  submitter_id  uuid        NOT NULL,
+  message       text        NOT NULL DEFAULT '',
+  status        text        NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending','accepted','rejected')),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(challenge_id, dataset_id)
+);
+
+CREATE INDEX idx_submissions_challenge ON public.challenge_submissions (challenge_id, created_at DESC);
+CREATE INDEX idx_submissions_submitter ON public.challenge_submissions (submitter_id, created_at DESC);
+
+ALTER TABLE public.challenge_submissions ENABLE ROW LEVEL SECURITY;
+
+-- Submitter can view own submissions
+CREATE POLICY "submissions_submitter_select" ON public.challenge_submissions FOR SELECT
+  TO authenticated
+  USING (auth.uid() = submitter_id);
+
+-- Submitter can insert (active challenges, own datasets, not own challenge)
+CREATE POLICY "submissions_submitter_insert" ON public.challenge_submissions FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = submitter_id
+    AND EXISTS (
+      SELECT 1 FROM public.challenges c
+      WHERE c.id = challenge_id AND c.status = 'active' AND c.user_id != auth.uid()
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.datasets d
+      WHERE d.id = dataset_id AND d.user_id = auth.uid() AND d.status = 'ready'
+    )
+  );
+
+-- Challenge owner can view submissions for their challenges
+CREATE POLICY "submissions_owner_select" ON public.challenge_submissions FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.challenges c
+    WHERE c.id = challenge_id AND c.user_id = auth.uid()
+  ));
+
+-- Challenge owner can update submission status
+CREATE POLICY "submissions_owner_update" ON public.challenge_submissions FOR UPDATE
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.challenges c
+    WHERE c.id = challenge_id AND c.user_id = auth.uid()
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.challenges c
+    WHERE c.id = challenge_id AND c.user_id = auth.uid()
+  ));
+
+-- Submission count trigger
+CREATE OR REPLACE FUNCTION public.update_challenge_submission_count()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    UPDATE public.challenges SET submission_count = submission_count + 1 WHERE id = NEW.challenge_id;
+  ELSIF TG_OP = 'DELETE' THEN
+    UPDATE public.challenges SET submission_count = submission_count - 1 WHERE id = OLD.challenge_id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER trg_submission_count
+  AFTER INSERT OR DELETE ON public.challenge_submissions
+  FOR EACH ROW EXECUTE FUNCTION public.update_challenge_submission_count();
+
+-- 4. Storage bucket for challenge media
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('challenge-media', 'challenge-media', false)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "challenge_media_storage_insert" ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'challenge-media'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+CREATE POLICY "challenge_media_storage_select" ON storage.objects FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'challenge-media'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+CREATE POLICY "challenge_media_storage_delete" ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'challenge-media'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Public read via signed URLs
+CREATE POLICY "challenge_media_storage_public_read" ON storage.objects FOR SELECT
+  TO anon, authenticated
+  USING (bucket_id = 'challenge-media');

--- a/supabase/migrations/20260425141000_creator_participant_roles.sql
+++ b/supabase/migrations/20260425141000_creator_participant_roles.sql
@@ -1,0 +1,23 @@
+-- Creator/Participant role support for challenge submissions
+
+-- Allow submitting to any active challenge, including own challenges
+DROP POLICY IF EXISTS "submissions_submitter_insert" ON public.challenge_submissions;
+
+CREATE POLICY "submissions_submitter_insert" ON public.challenge_submissions FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = submitter_id
+    AND EXISTS (
+      SELECT 1 FROM public.challenges c
+      WHERE c.id = challenge_id AND c.status = 'active'
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.datasets d
+      WHERE d.id = dataset_id AND d.user_id = auth.uid() AND d.status = 'ready'
+    )
+  );
+
+-- Allow submitters to withdraw only pending submissions
+CREATE POLICY "submissions_submitter_delete_pending" ON public.challenge_submissions FOR DELETE
+  TO authenticated
+  USING (auth.uid() = submitter_id AND status = 'pending');


### PR DESCRIPTION
## Background

This branch delivers the Challenges experience end-to-end and adds creator/participant role behavior on top of it.

The base Challenges feature introduces challenge creation, publishing, discovery, media, and submissions.  
The follow-up role work ensures the same logged-in user can act as both:
1. Challenge creator (manage created challenges, review participant submissions, accept/reject).
2. Challenge participant (submit datasets, track own submissions, withdraw pending ones, see accepted earnings).

Compensation remains display-only in this version (no payout execution workflow).

## Description

This PR adds the following user-facing capabilities:

1. Challenge creators can create and manage challenges from dashboard/editor flows.
2. Marketplace shows active challenges with filtering and challenge cards.
3. Participants can submit eligible datasets to active challenges.
4. Challenge owners can review submissions on challenge detail pages and accept/reject them.
5. Dashboard now clearly separates:
1. My Challenges: challenges created by the current user.
2. My Submissions: only submissions made by the current user as participant.
6. Pending participant submissions can be withdrawn.
7. Accepted submissions show compensation outcome in the participant dashboard.
8. Creator can review submission datasets with visualization flow and access accepted submission files.

## Implementation Details

1. Database and RLS:
1. Added Challenges schema and constraints (`challenges`, `challenge_media`, `challenge_submissions`) with indexes, status transition trigger, and submission count trigger.
2. Added migration `20260425141000_creator_participant_roles.sql` to:
1. Allow submitting to own active challenges.
2. Allow submitter-only deletion of pending submissions.

2. Services and types:
1. Added challenge service/media/submission service support for listing, publishing, status changes, moderation, and submission flows.
2. Extended submission service with:
1. `withdraw(id)`
2. `listMineEnriched()`
3. `listForChallengeEnriched(challengeId)`
3. Updated types for enriched submission rendering.

3. Routing and page behavior:
1. Editor routes:
1. `/dashboard/challenges/new`
2. `/dashboard/challenges/:id/edit`
2. Detail routes:
1. `/dashboard/challenges/:id` (protected)
2. `/marketplace/challenges/:id`
3. Updated challenge list/edit links to match route split.

4. Dashboard UX:
1. Added participant section label and behavior as `My Submissions`.
2. Fixed ownership bug by filtering participant dashboard submissions by authenticated `submitter_id`.
3. Kept challenge-owner submission moderation on challenge detail page only.

5. Edge functions:
1. Updated `get-dataset-manifest` access checks for creator/participant review scenarios.
2. Updated `dataset-read-urls` access checks to support accepted-submission access paths.

6. Tests:
1. Updated/added unit and integration coverage for:
1. submission withdraw behavior
2. enriched submission listing
3. dashboard challenge/submission rendering
4. auth-aware service behavior

## How to Test

1. Apply DB migration:
```bash
supabase migration up
```
Or manually run:
```sql
supabase/migrations/20260425141000_creator_participant_roles.sql
```

2. Redeploy edge functions:
```bash
supabase functions deploy get-dataset-manifest
supabase functions deploy dataset-read-urls
```

3. Run app:
```bash
npm install
npm run dev
```

4. Validate creator flow:
1. Create and publish challenge from dashboard.
2. Open My Challenges and confirm created challenges are listed.
3. Open a challenge detail and confirm participant submissions appear there.
4. Accept a submission and verify accepted-state actions.

5. Validate participant flow:
1. Submit a ready dataset to a challenge.
2. Open dashboard `My Submissions` and confirm only your own submissions are listed.
3. Withdraw a pending submission and verify it disappears.
4. Confirm accepted submission shows earnings text.

6. Run tests:
```bash
npm run test
npm run test:coverage
```