### PR TITLE
Fix unable to visualize and download submitted datasets

### DIFF
--- a/src/lib/visualizer.ts
+++ b/src/lib/visualizer.ts
@@ -23,12 +23,51 @@ function encodeManifest(manifest: unknown): string {
  * base64-encodes it using URL-safe Base64, and opens the visualizer in a new tab.
  */
 export async function openVisualizer(datasetId: string): Promise<void> {
-  const { data, error } = await supabase.functions.invoke("get-dataset-manifest", {
-    body: { dataset_id: datasetId },
-  });
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+
+  if (sessionError) {
+    throw new Error("Failed to resolve authentication session");
+  }
+
+  if (!session?.access_token) {
+    throw new Error("Please sign in to visualize this dataset");
+  }
+
+  const invokeManifest = async (accessToken: string) => {
+    return supabase.functions.invoke("get-dataset-manifest", {
+      body: { dataset_id: datasetId },
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+  };
+
+  let { data, error } = await invokeManifest(session.access_token);
+
+  const getStatus = (err: unknown): number | undefined => {
+    return (err as { context?: { status?: number }; status?: number })?.context?.status
+      ?? (err as { status?: number })?.status;
+  };
+
+  const status = getStatus(error);
+  if (error && (status === 401 || status === 403)) {
+    const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession();
+    if (!refreshError && refreshed.session?.access_token) {
+      const retried = await invokeManifest(refreshed.session.access_token);
+      data = retried.data;
+      error = retried.error;
+    }
+  }
 
   if (error) {
-    throw new Error(error.message || "Failed to fetch dataset manifest");
+    const finalStatus = getStatus(error);
+    if (finalStatus === 403) {
+      throw new Error("You do not have permission to visualize this dataset");
+    }
+    throw new Error((error as { message?: string }).message || "Failed to fetch dataset manifest");
   }
 
   const manifestBase64 = encodeManifest(data);

--- a/src/services/datasetService.ts
+++ b/src/services/datasetService.ts
@@ -86,11 +86,53 @@ export async function getDatasetFileUrls(
   datasetId: string,
   paths?: string[]
 ): Promise<SignedFileUrl[]> {
-  const { data, error } = await supabase.functions.invoke("dataset-read-urls", {
-    body: { dataset_id: datasetId, paths },
-  });
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
 
-  if (error) throw new Error(error.message || "Failed to get file URLs");
+  if (sessionError) {
+    throw new Error("Failed to resolve authentication session");
+  }
+
+  if (!session?.access_token) {
+    throw new Error("Please sign in to access dataset files");
+  }
+
+  const invokeReadUrls = async (accessToken: string) => {
+    return supabase.functions.invoke("dataset-read-urls", {
+      body: { dataset_id: datasetId, paths },
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+  };
+
+  let { data, error } = await invokeReadUrls(session.access_token);
+
+  const getStatus = (err: unknown): number | undefined => {
+    return (err as { context?: { status?: number }; status?: number })?.context?.status
+      ?? (err as { status?: number })?.status;
+  };
+
+  const status = getStatus(error);
+  if (error && (status === 401 || status === 403)) {
+    const { data: refreshed, error: refreshError } = await supabase.auth.refreshSession();
+    if (!refreshError && refreshed.session?.access_token) {
+      const retried = await invokeReadUrls(refreshed.session.access_token);
+      data = retried.data;
+      error = retried.error;
+    }
+  }
+
+  if (error) {
+    const finalStatus = getStatus(error);
+    if (finalStatus === 403) {
+      throw new Error("You do not have permission to access these dataset files");
+    }
+    throw new Error((error as { message?: string }).message || "Failed to get file URLs");
+  }
+
   return data?.urls ?? [];
 }
 

--- a/src/test/unit/lib/visualizer.test.ts
+++ b/src/test/unit/lib/visualizer.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { openVisualizer } from '@/lib/visualizer';
-import * as visualizerModule from '@/lib/visualizer';
-
-// Since encodeManifest is private, we'll test it indirectly through openVisualizer
-// or by accessing it via the module if needed
 
 // Mock the supabase client
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
+    auth: {
+      getSession: vi.fn(),
+      refreshSession: vi.fn(),
+    },
     functions: {
       invoke: vi.fn(),
     },
@@ -20,6 +20,15 @@ describe('visualizer - openVisualizer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (window.open as any).mockClear();
+    const mockSupabase = supabase as any;
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: { access_token: 'token_123' } },
+      error: null,
+    });
+    mockSupabase.auth.refreshSession.mockResolvedValue({
+      data: { session: { access_token: 'token_456' } },
+      error: null,
+    });
   });
 
   it('should invoke edge function with correct dataset_id', async () => {
@@ -35,6 +44,7 @@ describe('visualizer - openVisualizer', () => {
       'get-dataset-manifest',
       expect.objectContaining({
         body: expect.objectContaining({ dataset_id: 'ds_test_123' }),
+        headers: expect.objectContaining({ Authorization: 'Bearer token_123' }),
       })
     );
   });
@@ -96,6 +106,78 @@ describe('visualizer - openVisualizer', () => {
     await expect(openVisualizer('ds_test_123')).rejects.toThrow(
       'Failed to fetch dataset manifest'
     );
+  });
+
+  it('should throw friendly message for forbidden response', async () => {
+    const mockSupabase = supabase as any;
+    mockSupabase.functions.invoke
+      .mockResolvedValueOnce({
+        data: null,
+        error: { context: { status: 403 } },
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { context: { status: 403 } },
+      });
+
+    await expect(openVisualizer('ds_test_123')).rejects.toThrow(
+      'You do not have permission to visualize this dataset'
+    );
+  });
+
+  it('should refresh session and retry once on 403', async () => {
+    const mockSupabase = supabase as any;
+    mockSupabase.functions.invoke
+      .mockResolvedValueOnce({
+        data: null,
+        error: { context: { status: 403 } },
+      })
+      .mockResolvedValueOnce({
+        data: { files: [], metadata: {} },
+        error: null,
+      });
+
+    await openVisualizer('ds_test_123');
+
+    expect(mockSupabase.auth.refreshSession).toHaveBeenCalledTimes(1);
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(2);
+    expect(mockSupabase.functions.invoke).toHaveBeenLastCalledWith(
+      'get-dataset-manifest',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer token_456' }),
+      }),
+    );
+    expect(window.open).toHaveBeenCalled();
+  });
+
+  it('should not retry when refresh fails', async () => {
+    const mockSupabase = supabase as any;
+    mockSupabase.auth.refreshSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'refresh failed' },
+    });
+    mockSupabase.functions.invoke.mockResolvedValue({
+      data: null,
+      error: { context: { status: 403 } },
+    });
+
+    await expect(openVisualizer('ds_test_123')).rejects.toThrow(
+      'You do not have permission to visualize this dataset'
+    );
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail when no auth session is available', async () => {
+    const mockSupabase = supabase as any;
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    await expect(openVisualizer('ds_test_123')).rejects.toThrow(
+      'Please sign in to visualize this dataset'
+    );
+    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
   });
 
   it('should handle unicode in manifest data', async () => {

--- a/src/test/unit/services/datasetService.test.ts
+++ b/src/test/unit/services/datasetService.test.ts
@@ -3,6 +3,10 @@ import { listDatasets, getDataset, getDatasetFiles, getDatasetFileUrls } from "@
 
 const mockSupabase = vi.hoisted(() => ({
   from: vi.fn(),
+  auth: {
+    getSession: vi.fn(),
+    refreshSession: vi.fn(),
+  },
   functions: {
     invoke: vi.fn(),
   },
@@ -24,6 +28,14 @@ function createSelectQuery(data: any[], singleData: any = data[0] ?? null) {
 describe("datasetService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: { access_token: "token_123" } },
+      error: null,
+    });
+    mockSupabase.auth.refreshSession.mockResolvedValue({
+      data: { session: { access_token: "token_456" } },
+      error: null,
+    });
   });
 
   afterEach(() => {
@@ -178,6 +190,13 @@ describe("datasetService", () => {
         signed_url: "https://example.com/meta.json",
       }),
     ]);
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith(
+      "dataset-read-urls",
+      expect.objectContaining({
+        body: { dataset_id: "ds_1", paths: ["meta/info.json"] },
+        headers: { Authorization: "Bearer token_123" },
+      }),
+    );
 
     mockSupabase.functions.invoke.mockResolvedValue({
       data: null,
@@ -185,5 +204,43 @@ describe("datasetService", () => {
     });
 
     await expect(getDatasetFileUrls("ds_1")).rejects.toThrow("Edge function failed");
+  });
+
+  it("retries once with refreshed token on 403 and succeeds", async () => {
+    mockSupabase.functions.invoke
+      .mockResolvedValueOnce({
+        data: null,
+        error: { context: { status: 403 } },
+      })
+      .mockResolvedValueOnce({
+        data: { urls: [] },
+        error: null,
+      });
+
+    await expect(getDatasetFileUrls("ds_1")).resolves.toEqual([]);
+    expect(mockSupabase.auth.refreshSession).toHaveBeenCalledTimes(1);
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(2);
+    expect(mockSupabase.functions.invoke).toHaveBeenLastCalledWith(
+      "dataset-read-urls",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer token_456" },
+      }),
+    );
+  });
+
+  it("returns a friendly message for persistent 403", async () => {
+    mockSupabase.functions.invoke
+      .mockResolvedValueOnce({
+        data: null,
+        error: { context: { status: 403 } },
+      })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { context: { status: 403 } },
+      });
+
+    await expect(getDatasetFileUrls("ds_1")).rejects.toThrow(
+      "You do not have permission to access these dataset files"
+    );
   });
 });

--- a/supabase/functions/get-dataset-manifest/index.ts
+++ b/supabase/functions/get-dataset-manifest/index.ts
@@ -19,21 +19,54 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
 };
 
-function jsonError(message: string, status: number) {
-  return new Response(JSON.stringify({ error: message }), {
+function logInfo(requestId: string, message: string, extra: Record<string, unknown> = {}) {
+  console.log(
+    JSON.stringify({
+      request_id: requestId,
+      message,
+      ...extra,
+    }),
+  );
+}
+
+function logError(requestId: string, message: string, extra: Record<string, unknown> = {}) {
+  console.error(
+    JSON.stringify({
+      request_id: requestId,
+      message,
+      ...extra,
+    }),
+  );
+}
+
+function jsonError(
+  message: string,
+  status: number,
+  requestId?: string,
+  extra: Record<string, unknown> = {},
+) {
+  return new Response(JSON.stringify({ error: message, ...extra }), {
     status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+      ...(requestId ? { "x-request-id": requestId } : {}),
+    },
   });
 }
 
-function jsonOk(body: unknown) {
+function jsonOk(body: unknown, requestId?: string) {
   return new Response(JSON.stringify(body), {
     status: 200,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+      ...(requestId ? { "x-request-id": requestId } : {}),
+    },
   });
 }
 
-async function handleManifest(datasetId: string, jwt: string) {
+async function handleManifest(datasetId: string, jwt: string, requestId: string) {
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
   const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
@@ -49,10 +82,12 @@ async function handleManifest(datasetId: string, jwt: string) {
   } = await userClient.auth.getUser();
 
   if (userError || !user) {
-    return jsonError("Invalid or expired token", 401);
+    logInfo(requestId, "auth_user_failed", { user_error: userError?.message ?? null });
+    return jsonError("Invalid or expired token", 401, requestId);
   }
 
   const adminClient = createClient(supabaseUrl, serviceRoleKey);
+  logInfo(requestId, "auth_user_ok", { user_id: user.id, dataset_id: datasetId });
 
   // Fetch dataset and resolve access rules
   const { data: dataset, error: dsError } = await adminClient
@@ -62,11 +97,12 @@ async function handleManifest(datasetId: string, jwt: string) {
     .maybeSingle();
 
   if (dsError) {
-    console.error("Dataset lookup error:", dsError);
-    return jsonError("Internal error", 500);
+    logError(requestId, "dataset_lookup_error", { error: dsError.message });
+    return jsonError("Internal error", 500, requestId);
   }
   if (!dataset) {
-    return jsonError("Dataset not found", 404);
+    logInfo(requestId, "dataset_not_found", { dataset_id: datasetId });
+    return jsonError("Dataset not found", 404, requestId);
   }
 
   const isDatasetOwner = dataset.user_id === user.id;
@@ -79,8 +115,8 @@ async function handleManifest(datasetId: string, jwt: string) {
       .limit(1)
       .maybeSingle();
     if (submitterError) {
-      console.error("Submission access (submitter) error:", submitterError);
-      return jsonError("Internal error", 500);
+      logError(requestId, "submitter_access_lookup_error", { error: submitterError.message });
+      return jsonError("Internal error", 500, requestId);
     }
 
     let isChallengeOwner = false;
@@ -89,8 +125,8 @@ async function handleManifest(datasetId: string, jwt: string) {
       .select("challenge_id")
       .eq("dataset_id", datasetId);
     if (ownerChallengeError) {
-      console.error("Submission access (challenge rows) error:", ownerChallengeError);
-      return jsonError("Internal error", 500);
+      logError(requestId, "challenge_rows_lookup_error", { error: ownerChallengeError.message });
+      return jsonError("Internal error", 500, requestId);
     }
 
     const challengeIds = [...new Set((ownerChallengeRows ?? []).map((r) => r.challenge_id))];
@@ -103,15 +139,37 @@ async function handleManifest(datasetId: string, jwt: string) {
         .limit(1)
         .maybeSingle();
       if (ownerError) {
-        console.error("Submission access (challenge owner) error:", ownerError);
-        return jsonError("Internal error", 500);
+        logError(requestId, "challenge_owner_lookup_error", { error: ownerError.message });
+        return jsonError("Internal error", 500, requestId);
       }
       isChallengeOwner = !!ownerChallenge;
     }
 
     if (!submitterSubmission && !isChallengeOwner) {
-      return jsonError("Access denied", 403);
+      logInfo(requestId, "access_denied", {
+        user_id: user.id,
+        dataset_id: datasetId,
+        dataset_owner_id: dataset.user_id,
+        has_submitter_submission: !!submitterSubmission,
+        challenge_ids_count: challengeIds.length,
+        is_challenge_owner: isChallengeOwner,
+      });
+      return jsonError("Access denied", 403, requestId, {
+        reason: "not_dataset_owner_submitter_or_challenge_owner",
+      });
     }
+
+    logInfo(requestId, "access_granted_via_submission_path", {
+      user_id: user.id,
+      dataset_id: datasetId,
+      has_submitter_submission: !!submitterSubmission,
+      is_challenge_owner: isChallengeOwner,
+    });
+  } else {
+    logInfo(requestId, "access_granted_dataset_owner", {
+      user_id: user.id,
+      dataset_id: datasetId,
+    });
   }
 
   // Fetch uploaded files
@@ -123,12 +181,13 @@ async function handleManifest(datasetId: string, jwt: string) {
     .order("relative_path");
 
   if (filesError) {
-    console.error("Files lookup error:", filesError);
-    return jsonError("Internal error fetching files", 500);
+    logError(requestId, "files_lookup_error", { error: filesError.message });
+    return jsonError("Internal error fetching files", 500, requestId);
   }
 
   if (!files || files.length === 0) {
-    return jsonError("Dataset contains no files", 404);
+    logInfo(requestId, "files_empty", { dataset_id: datasetId });
+    return jsonError("Dataset contains no files", 404, requestId);
   }
 
   // Generate signed URLs (batch)
@@ -138,8 +197,8 @@ async function handleManifest(datasetId: string, jwt: string) {
     .createSignedUrls(storagePaths, 3600);
 
   if (signedError) {
-    console.error("Signed URL error:", signedError);
-    return jsonError("Failed to generate signed URLs", 500);
+    logError(requestId, "signed_url_error", { error: signedError.message });
+    return jsonError("Failed to generate signed URLs", 500, requestId);
   }
 
   const manifest = {
@@ -150,18 +209,26 @@ async function handleManifest(datasetId: string, jwt: string) {
     })),
   };
 
-  return jsonOk(manifest);
+  logInfo(requestId, "manifest_ok", { dataset_id: datasetId, file_count: files.length });
+  return jsonOk(manifest, requestId);
 }
 
 Deno.serve(async (req) => {
+  const requestId = crypto.randomUUID();
+
   if (req.method === "OPTIONS") {
+    logInfo(requestId, "preflight");
     return new Response(null, { headers: corsHeaders });
   }
+
+  const url = new URL(req.url);
+  logInfo(requestId, "request_start", { method: req.method, pathname: url.pathname });
 
   // Auth
   const authHeader = req.headers.get("Authorization");
   if (!authHeader?.startsWith("Bearer ")) {
-    return jsonError("Missing authorization", 401);
+    logInfo(requestId, "missing_authorization");
+    return jsonError("Missing authorization", 401, requestId);
   }
   const jwt = authHeader.replace("Bearer ", "").trim();
 
@@ -172,11 +239,11 @@ Deno.serve(async (req) => {
       const body = await req.json();
       datasetId = body.dataset_id ?? null;
     } catch {
-      return jsonError("Malformed JSON body", 400);
+      logInfo(requestId, "malformed_json_body");
+      return jsonError("Malformed JSON body", 400, requestId);
     }
   } else if (req.method === "GET") {
     // Support ?dataset_id=... query param (used when Cloudflare proxies GET /datasets/{id})
-    const url = new URL(req.url);
     datasetId = url.searchParams.get("dataset_id");
 
     // Also support path-based: /get-dataset-manifest/{dataset_id}
@@ -188,12 +255,14 @@ Deno.serve(async (req) => {
       }
     }
   } else {
-    return jsonError("Method not allowed", 405);
+    logInfo(requestId, "method_not_allowed", { method: req.method });
+    return jsonError("Method not allowed", 405, requestId);
   }
 
   if (!datasetId || typeof datasetId !== "string") {
-    return jsonError("Missing or invalid 'dataset_id'", 400);
+    logInfo(requestId, "dataset_id_missing_or_invalid");
+    return jsonError("Missing or invalid 'dataset_id'", 400, requestId);
   }
 
-  return handleManifest(datasetId, jwt);
+  return handleManifest(datasetId, jwt, requestId);
 });


### PR DESCRIPTION
## Background
Challenge owners were seeing failures when trying to review accepted/submitted datasets:

- `Visualize` failed with `Edge Function returned a non-2xx status code` / `403 (Forbidden)`.
- `Access Files` (download flow) also failed with `403 (Forbidden)` and showed empty file lists.

The underlying issue was inconsistent auth handling in frontend edge-function calls, plus limited observability in the `get-dataset-manifest` edge function when access checks failed.

## Description of PR
This PR hardens dataset visualization/download flows by:

- Explicitly attaching the current Supabase access token to edge function invocations.
- Retrying once after session refresh on `401/403` (token expiry/staleness).
- Returning clearer user-facing errors for true permission-denied cases.
- Adding structured request-level logging and request IDs to `get-dataset-manifest` for faster diagnosis of backend authorization failures.
- Extending unit tests for both visualizer and dataset-read URL flows.

## Implementation Details
### Frontend auth hardening
- Updated `openVisualizer` in `src/lib/visualizer.ts`:
  - Reads session via `supabase.auth.getSession()`.
  - Sends `Authorization: Bearer <token>` in `get-dataset-manifest` invoke.
  - Retries once after `supabase.auth.refreshSession()` when response status is `401/403`.
  - Surfaces specific error for `403`: `"You do not have permission to visualize this dataset"`.

- Updated `getDatasetFileUrls` in `src/services/datasetService.ts`:
  - Same token/header behavior for `dataset-read-urls`.
  - Same one-time refresh/retry strategy on `401/403`.
  - Surfaces specific error for `403`: `"You do not have permission to access these dataset files"`.

### Edge function observability
- Updated `supabase/functions/get-dataset-manifest/index.ts`:
  - Added structured logs (`request_start`, auth outcome, access-path decisions, lookup/signing errors, success).
  - Added per-request correlation ID (`request_id`) and `x-request-id` response header.
  - Included explicit deny reason payload on `403`:
    - `reason: "not_dataset_owner_submitter_or_challenge_owner"`.

### Tests
- `src/test/unit/lib/visualizer.test.ts`:
  - Added auth/session mocks.
  - Asserts auth header is passed.
  - Covers retry on `403`, retry failure path, missing-session path, and friendly permission error.

- `src/test/unit/services/datasetService.test.ts`:
  - Added auth/session mocks.
  - Asserts auth header is passed.
  - Covers retry on `403` and persistent `403` friendly error.

## How to Test
1. Install deps:
   - `npm ci`
2. Run targeted unit tests:
   - `npm run test -- src/test/unit/lib/visualizer.test.ts`
   - `npm run test -- src/test/unit/services/datasetService.test.ts`
3. Deploy edge function updates (important for enhanced logs/diagnostics):
   - `supabase/functions/get-dataset-manifest/index.ts`
4. Manual verification in app:
   - As challenge owner, click **Visualize** on a submitted dataset.
   - As challenge owner, click **Access Files** on an accepted submission.
   - Confirm no generic non-2xx popup for valid access.
5. If access is still denied, inspect Network response headers/body:
   - Capture `x-request-id` and error payload.
   - Correlate with edge logs using `request_id` to identify exact failing access branch.
