### PR TITLE
Fix user access permission to datasets in challenges and submissions

### DIFF
--- a/supabase/functions/_shared/dataset_access.ts
+++ b/supabase/functions/_shared/dataset_access.ts
@@ -1,0 +1,92 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+
+type ChallengeSubmissionAccessRow = {
+  submitter_id: string;
+  status: "pending" | "accepted" | "rejected";
+  challenge_id: string;
+};
+
+export type DatasetAccessResolution = {
+  isDatasetOwner: boolean;
+  isSubmitter: boolean;
+  isChallengeOwner: boolean;
+  isAcceptedChallengeOwner: boolean;
+  submissionCount: number;
+};
+
+export async function resolveDatasetAccess(params: {
+  supabaseUrl: string;
+  serviceRoleKey: string;
+  datasetId: string;
+  userId: string;
+  datasetOwnerId: string;
+}) {
+  const adminClient = createClient(params.supabaseUrl, params.serviceRoleKey);
+
+  const isDatasetOwner = params.datasetOwnerId === params.userId;
+  if (isDatasetOwner) {
+    return {
+      data: {
+        isDatasetOwner: true,
+        isSubmitter: false,
+        isChallengeOwner: false,
+        isAcceptedChallengeOwner: false,
+        submissionCount: 0,
+      } satisfies DatasetAccessResolution,
+      error: null,
+    };
+  }
+
+  const { data: submissionRows, error: submissionError } = await adminClient
+    .from("challenge_submissions")
+    .select("challenge_id, submitter_id, status")
+    .eq("dataset_id", params.datasetId);
+
+  if (submissionError) {
+    return { data: null, error: submissionError };
+  }
+
+  const rows = (submissionRows ?? []) as ChallengeSubmissionAccessRow[];
+  const isSubmitter = rows.some((row) => row.submitter_id === params.userId);
+
+  const challengeIds = [...new Set(rows.map((row) => row.challenge_id))];
+  if (challengeIds.length === 0) {
+    return {
+      data: {
+        isDatasetOwner: false,
+        isSubmitter,
+        isChallengeOwner: false,
+        isAcceptedChallengeOwner: false,
+        submissionCount: rows.length,
+      } satisfies DatasetAccessResolution,
+      error: null,
+    };
+  }
+
+  const { data: ownedChallenges, error: ownedChallengesError } = await adminClient
+    .from("challenges")
+    .select("id")
+    .eq("user_id", params.userId)
+    .in("id", challengeIds);
+
+  if (ownedChallengesError) {
+    return { data: null, error: ownedChallengesError };
+  }
+
+  const ownedChallengeIds = new Set((ownedChallenges ?? []).map((row: any) => row.id as string));
+  const isChallengeOwner = rows.some((row) => ownedChallengeIds.has(row.challenge_id));
+  const isAcceptedChallengeOwner = rows.some(
+    (row) => row.status === "accepted" && ownedChallengeIds.has(row.challenge_id),
+  );
+
+  return {
+    data: {
+      isDatasetOwner: false,
+      isSubmitter,
+      isChallengeOwner,
+      isAcceptedChallengeOwner,
+      submissionCount: rows.length,
+    } satisfies DatasetAccessResolution,
+    error: null,
+  };
+}

--- a/supabase/functions/dataset-read-urls/handler.ts
+++ b/supabase/functions/dataset-read-urls/handler.ts
@@ -13,6 +13,7 @@
  */
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+import { resolveDatasetAccess } from "../_shared/dataset_access.ts";
 import { createEdgeLogger, serializeError } from "../_shared/logging.ts";
 
 const corsHeaders = {
@@ -98,66 +99,31 @@ export async function handler(req: Request): Promise<Response> {
       return log.complete(log.jsonError("Dataset not found", 404));
     }
 
-    const isDatasetOwner = dataset.user_id === user.id;
-    if (!isDatasetOwner) {
-      const { data: submitterSubmission, error: submitterError } = await adminClient
-        .from("challenge_submissions")
-        .select("id")
-        .eq("dataset_id", body.dataset_id)
-        .eq("submitter_id", user.id)
-        .limit(1)
-        .maybeSingle();
-      if (submitterError) {
-        log.error("submitter_access_lookup_error", {
-          user_id: user.id,
-          dataset_id: body.dataset_id,
-          db_error: submitterError.message,
-        });
-        return log.complete(log.jsonError("Internal error", 500));
-      }
+    const { data: access, error: accessError } = await resolveDatasetAccess({
+      supabaseUrl,
+      serviceRoleKey,
+      datasetId: body.dataset_id,
+      userId: user.id,
+      datasetOwnerId: dataset.user_id,
+    });
 
-      const { data: acceptedRows, error: acceptedRowsError } = await adminClient
-        .from("challenge_submissions")
-        .select("challenge_id")
-        .eq("dataset_id", body.dataset_id)
-        .eq("status", "accepted");
-      if (acceptedRowsError) {
-        log.error("accepted_submission_lookup_error", {
-          user_id: user.id,
-          dataset_id: body.dataset_id,
-          db_error: acceptedRowsError.message,
-        });
-        return log.complete(log.jsonError("Internal error", 500));
-      }
+    if (accessError) {
+      log.error("dataset_access_lookup_error", {
+        user_id: user.id,
+        dataset_id: body.dataset_id,
+        db_error: accessError.message,
+      });
+      return log.complete(log.jsonError("Internal error", 500));
+    }
 
-      let isAcceptedChallengeOwner = false;
-      const acceptedChallengeIds = [...new Set((acceptedRows ?? []).map((r: any) => r.challenge_id))];
-      if (acceptedChallengeIds.length > 0) {
-        const { data: ownerChallenge, error: ownerError } = await adminClient
-          .from("challenges")
-          .select("id")
-          .eq("user_id", user.id)
-          .in("id", acceptedChallengeIds)
-          .limit(1)
-          .maybeSingle();
-        if (ownerError) {
-          log.error("challenge_owner_lookup_error", {
-            user_id: user.id,
-            dataset_id: body.dataset_id,
-            db_error: ownerError.message,
-          });
-          return log.complete(log.jsonError("Internal error", 500));
-        }
-        isAcceptedChallengeOwner = !!ownerChallenge;
-      }
-
-      if (!submitterSubmission && !isAcceptedChallengeOwner) {
+    if (!access?.isDatasetOwner) {
+      if (!access?.isSubmitter && !access?.isAcceptedChallengeOwner) {
         log.warn("dataset_access_denied", {
           user_id: user.id,
           dataset_id: body.dataset_id,
           dataset_owner_id: dataset.user_id,
-          has_submitter_submission: !!submitterSubmission,
-          is_accepted_challenge_owner: isAcceptedChallengeOwner,
+          has_submitter_submission: !!access?.isSubmitter,
+          is_accepted_challenge_owner: !!access?.isAcceptedChallengeOwner,
         });
         return log.complete(log.jsonError("Access denied", 403));
       }

--- a/supabase/functions/get-dataset-manifest/handler.ts
+++ b/supabase/functions/get-dataset-manifest/handler.ts
@@ -12,6 +12,7 @@
  */
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.4";
+import { resolveDatasetAccess } from "../_shared/dataset_access.ts";
 import { createEdgeLogger, serializeError } from "../_shared/logging.ts";
 
 const corsHeaders = {
@@ -63,54 +64,28 @@ async function handleManifest(
     return log.jsonError("Dataset not found", 404);
   }
 
-  const isDatasetOwner = dataset.user_id === user.id;
-  if (!isDatasetOwner) {
-    const { data: submitterSubmission, error: submitterError } = await adminClient
-      .from("challenge_submissions")
-      .select("id")
-      .eq("dataset_id", datasetId)
-      .eq("submitter_id", user.id)
-      .limit(1)
-      .maybeSingle();
-    if (submitterError) {
-      log.error("submitter_access_lookup_error", { db_error: submitterError.message });
-      return log.jsonError("Internal error", 500);
-    }
+  const { data: access, error: accessError } = await resolveDatasetAccess({
+    supabaseUrl,
+    serviceRoleKey,
+    datasetId,
+    userId: user.id,
+    datasetOwnerId: dataset.user_id,
+  });
 
-    let isChallengeOwner = false;
-    const { data: ownerChallengeRows, error: ownerChallengeError } = await adminClient
-      .from("challenge_submissions")
-      .select("challenge_id")
-      .eq("dataset_id", datasetId);
-    if (ownerChallengeError) {
-      log.error("challenge_rows_lookup_error", { db_error: ownerChallengeError.message });
-      return log.jsonError("Internal error", 500);
-    }
+  if (accessError) {
+    log.error("dataset_access_lookup_error", { db_error: accessError.message });
+    return log.jsonError("Internal error", 500);
+  }
 
-    const challengeIds = [...new Set((ownerChallengeRows ?? []).map((r: any) => r.challenge_id))];
-    if (challengeIds.length > 0) {
-      const { data: ownerChallenge, error: ownerError } = await adminClient
-        .from("challenges")
-        .select("id")
-        .eq("user_id", user.id)
-        .in("id", challengeIds)
-        .limit(1)
-        .maybeSingle();
-      if (ownerError) {
-        log.error("challenge_owner_lookup_error", { db_error: ownerError.message });
-        return log.jsonError("Internal error", 500);
-      }
-      isChallengeOwner = !!ownerChallenge;
-    }
-
-    if (!submitterSubmission && !isChallengeOwner) {
+  if (!access?.isDatasetOwner) {
+    if (!access?.isSubmitter && !access?.isChallengeOwner) {
       log.warn("access_denied", {
         user_id: user.id,
         dataset_id: datasetId,
         dataset_owner_id: dataset.user_id,
-        has_submitter_submission: !!submitterSubmission,
-        challenge_ids_count: challengeIds.length,
-        is_challenge_owner: isChallengeOwner,
+        has_submitter_submission: !!access?.isSubmitter,
+        challenge_ids_count: access?.submissionCount ?? 0,
+        is_challenge_owner: !!access?.isChallengeOwner,
       });
       return log.jsonError("Access denied", 403, {
         reason: "not_dataset_owner_submitter_or_challenge_owner",
@@ -120,8 +95,8 @@ async function handleManifest(
     log.info("access_granted_via_submission_path", {
       user_id: user.id,
       dataset_id: datasetId,
-      has_submitter_submission: !!submitterSubmission,
-      is_challenge_owner: isChallengeOwner,
+      has_submitter_submission: !!access?.isSubmitter,
+      is_challenge_owner: !!access?.isChallengeOwner,
     });
   } else {
     log.info("access_granted_dataset_owner", {

--- a/supabase/functions/test/dataset_read_urls_test.ts
+++ b/supabase/functions/test/dataset_read_urls_test.ts
@@ -34,3 +34,75 @@ Deno.test("dataset-read-urls: owner success", async () => {
   assertEquals(body.urls[0].relative_path, "a.txt");
   assertQueueExhausted();
 });
+
+Deno.test("dataset-read-urls: challenge owner with accepted submission success", async () => {
+  resetMocks();
+  setEnv(DEFAULT_ENV);
+  pushResult("auth.getUser", { data: { user: { id: "u2" } }, error: null });
+  pushResult("from(datasets).maybeSingle", { data: { id: "d1", user_id: "u3" }, error: null });
+  pushResult("from(challenge_submissions).select", {
+    data: [{ challenge_id: "c1", submitter_id: "u3", status: "accepted" }],
+    error: null,
+  });
+  pushResult("from(challenges).select", { data: [{ id: "c1" }], error: null });
+  pushResult("from(dataset_files).select", { data: [{ relative_path: "a.txt", storage_path: "u3/d1/a.txt", content_type: "text/plain" }], error: null });
+  pushResult("storage(datasets).createSignedUrls", { data: [{ signedUrl: "https://s/a" }], error: null });
+
+  const res = await handler(makeRequest("POST", "https://t/dru", { dataset_id: "d1" }, { Authorization: MOCK_JWT }));
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.urls.length, 1);
+  assertQueueExhausted();
+});
+
+Deno.test("dataset-read-urls: challenge owner denied when submission not accepted", async () => {
+  resetMocks();
+  setEnv(DEFAULT_ENV);
+  pushResult("auth.getUser", { data: { user: { id: "u2" } }, error: null });
+  pushResult("from(datasets).maybeSingle", { data: { id: "d1", user_id: "u3" }, error: null });
+  pushResult("from(challenge_submissions).select", {
+    data: [{ challenge_id: "c1", submitter_id: "u3", status: "pending" }],
+    error: null,
+  });
+  pushResult("from(challenges).select", { data: [{ id: "c1" }], error: null });
+
+  const res = await handler(makeRequest("POST", "https://t/dru", { dataset_id: "d1" }, { Authorization: MOCK_JWT }));
+  assertEquals(res.status, 403);
+  assertQueueExhausted();
+});
+
+Deno.test("dataset-read-urls: access denied for unrelated user", async () => {
+  resetMocks();
+  setEnv(DEFAULT_ENV);
+  pushResult("auth.getUser", { data: { user: { id: "u9" } }, error: null });
+  pushResult("from(datasets).maybeSingle", { data: { id: "d1", user_id: "u3" }, error: null });
+  pushResult("from(challenge_submissions).select", {
+    data: [{ challenge_id: "c1", submitter_id: "u3", status: "accepted" }],
+    error: null,
+  });
+  pushResult("from(challenges).select", { data: [], error: null });
+
+  const res = await handler(makeRequest("POST", "https://t/dru", { dataset_id: "d1" }, { Authorization: MOCK_JWT }));
+  assertEquals(res.status, 403);
+  assertQueueExhausted();
+});
+
+Deno.test("dataset-read-urls: submitter success", async () => {
+  resetMocks();
+  setEnv(DEFAULT_ENV);
+  pushResult("auth.getUser", { data: { user: { id: "u3" } }, error: null });
+  pushResult("from(datasets).maybeSingle", { data: { id: "d1", user_id: "u4" }, error: null });
+  pushResult("from(challenge_submissions).select", {
+    data: [{ challenge_id: "c1", submitter_id: "u3", status: "pending" }],
+    error: null,
+  });
+  pushResult("from(challenges).select", { data: [], error: null });
+  pushResult("from(dataset_files).select", { data: [{ relative_path: "b.txt", storage_path: "u4/d1/b.txt", content_type: "text/plain" }], error: null });
+  pushResult("storage(datasets).createSignedUrls", { data: [{ signedUrl: "https://s/b" }], error: null });
+
+  const res = await handler(makeRequest("POST", "https://t/dru", { dataset_id: "d1" }, { Authorization: MOCK_JWT }));
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.urls.length, 1);
+  assertQueueExhausted();
+});

--- a/supabase/functions/test/get_dataset_manifest_test.ts
+++ b/supabase/functions/test/get_dataset_manifest_test.ts
@@ -32,3 +32,59 @@ Deno.test("get-dataset-manifest: owner success", async () => {
   assertEquals(body.files.length, 1);
   assertQueueExhausted();
 });
+
+Deno.test("get-dataset-manifest: challenge owner (any status) success", async () => {
+  resetMocks();
+  setEnv(DEFAULT_ENV);
+  pushResult("auth.getUser", { data: { user: { id: "u2" } }, error: null });
+  pushResult("from(datasets).maybeSingle", { data: { id: "d1", user_id: "u3" }, error: null });
+  pushResult("from(challenge_submissions).select", {
+    data: [{ challenge_id: "c1", submitter_id: "u3", status: "rejected" }],
+    error: null,
+  });
+  pushResult("from(challenges).select", { data: [{ id: "c1" }], error: null });
+  pushResult("from(dataset_files).select", { data: [{ relative_path: "a", storage_path: "u3/d1/a" }], error: null });
+  pushResult("storage(datasets).createSignedUrls", { data: [{ signedUrl: "https://s/a" }], error: null });
+
+  const res = await handler(makeRequest("POST", "https://t/gdm", { dataset_id: "d1" }, { Authorization: MOCK_JWT }));
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.dataset_id, "d1");
+  assertQueueExhausted();
+});
+
+Deno.test("get-dataset-manifest: access denied for unrelated user", async () => {
+  resetMocks();
+  setEnv(DEFAULT_ENV);
+  pushResult("auth.getUser", { data: { user: { id: "u9" } }, error: null });
+  pushResult("from(datasets).maybeSingle", { data: { id: "d1", user_id: "u3" }, error: null });
+  pushResult("from(challenge_submissions).select", {
+    data: [{ challenge_id: "c1", submitter_id: "u3", status: "pending" }],
+    error: null,
+  });
+  pushResult("from(challenges).select", { data: [], error: null });
+
+  const res = await handler(makeRequest("POST", "https://t/gdm", { dataset_id: "d1" }, { Authorization: MOCK_JWT }));
+  assertEquals(res.status, 403);
+  const body = await res.json();
+  assertEquals(body.error, "Access denied");
+  assertQueueExhausted();
+});
+
+Deno.test("get-dataset-manifest: submitter success", async () => {
+  resetMocks();
+  setEnv(DEFAULT_ENV);
+  pushResult("auth.getUser", { data: { user: { id: "u3" } }, error: null });
+  pushResult("from(datasets).maybeSingle", { data: { id: "d1", user_id: "u4" }, error: null });
+  pushResult("from(challenge_submissions).select", {
+    data: [{ challenge_id: "c1", submitter_id: "u3", status: "pending" }],
+    error: null,
+  });
+  pushResult("from(challenges).select", { data: [], error: null });
+  pushResult("from(dataset_files).select", { data: [{ relative_path: "a", storage_path: "u4/d1/a" }], error: null });
+  pushResult("storage(datasets).createSignedUrls", { data: [{ signedUrl: "https://s/a" }], error: null });
+
+  const res = await handler(makeRequest("POST", "https://t/gdm", { dataset_id: "d1" }, { Authorization: MOCK_JWT }));
+  assertEquals(res.status, 200);
+  assertQueueExhausted();
+});


### PR DESCRIPTION
## Background

Challenge creators can review datasets submitted to their challenges, but the permission checks for dataset visualization and file access were too narrow.

Two issues were observed:

1. Challenge creators could not visualize submitted datasets, even though they should be able to inspect any dataset submitted to their own challenge regardless of submission status.
2. Challenge creators could not access dataset files after accepting a submission, even though accepted submissions should become downloadable to the challenge creator.

Both failures surfaced as `403 Access denied` responses from the relevant Supabase edge functions.

## Description

This PR fixes dataset access control for challenge submission workflows.

After this change:

- A challenge creator can visualize any dataset submitted to their challenge, regardless of whether the submission is `pending`, `accepted`, or `rejected`.
- A challenge creator can access dataset files only when the submission to their challenge has been `accepted`.
- Existing access for dataset owners and submitters is preserved.
- Unrelated users remain denied.

## Implementation Details

### Shared access resolution

Introduced a shared helper for dataset access resolution:

- `supabase/functions/_shared/dataset_access.ts`

This helper centralizes permission evaluation for a dataset by checking:

- whether the caller is the dataset owner
- whether the caller is the submitter
- whether the caller owns a challenge the dataset was submitted to
- whether the caller owns a challenge with an `accepted` submission for that dataset

This removes duplicated and partially divergent permission logic across edge functions.

### `get-dataset-manifest`

Updated the manifest access logic so that visualization is allowed when the caller is:

- the dataset owner
- the submitter
- the owner of a challenge the dataset was submitted to

This ensures challenge creators can inspect all submissions to their challenges regardless of status.

### `dataset-read-urls`

Updated dataset file access logic so that file URLs are allowed when the caller is:

- the dataset owner
- the submitter
- the owner of a challenge where that dataset submission is `accepted`

This preserves the intended restriction that challenge creators only gain download access after acceptance.

### Tests

Expanded edge-function tests to cover:

- challenge owner visualization success for non-accepted submissions
- challenge owner file access success for accepted submissions
- challenge owner file access denial for non-accepted submissions
- submitter access success
- unrelated user access denial

## How to Test

### Manual app flow

Create or use three users:

- `challenge_owner`
- `dataset_submitter`
- `unrelated_user`

Prepare one dataset owned by `dataset_submitter`, then submit it to a challenge owned by `challenge_owner`.

#### Visualization checks

1. Sign in as `challenge_owner`
2. Open the challenge detail page
3. On a submitted dataset with status `pending`, click **Visualize**
4. Confirm the visualizer opens successfully
5. Repeat with status `rejected`
6. Repeat with status `accepted`

Expected result:
- Visualization works for all three statuses

#### Download checks

1. Sign in as `challenge_owner`
2. On a `pending` submission, click **Access Files**

Expected result:
- Access is denied

3. Accept the submission
4. Click **Access Files** again

Expected result:
- File access succeeds and signed URLs are returned

5. Optionally switch to `rejected` and retry

Expected result:
- Access is denied unless the submission is `accepted`

#### Access control checks

1. Sign in as `dataset_submitter`

Expected result:
- Visualization and file access both succeed

2. Sign in as `unrelated_user`

Expected result:
- Visualization and file access are both denied

### Network verification

In browser DevTools, verify these requests:

- `POST /functions/v1/get-dataset-manifest`
- `POST /functions/v1/dataset-read-urls`

Expected responses:

- `get-dataset-manifest`
  - `200` for dataset owner
  - `200` for submitter
  - `200` for challenge owner on any submitted dataset
  - `403` for unrelated user

- `dataset-read-urls`
  - `200` for dataset owner
  - `200` for submitter
  - `200` for challenge owner only when submission is `accepted`
  - `403` for unrelated user
  - `403` for challenge owner when submission is not accepted

### Direct API verification

Call the edge functions with different user JWTs and the same `dataset_id`.

`get-dataset-manifest`
```bash
curl -i \
  -X POST "https://<project>.supabase.co/functions/v1/get-dataset-manifest" \
  -H "Authorization: Bearer <JWT>" \
  -H "Content-Type: application/json" \
  -d '{"dataset_id":"<DATASET_ID>"}'
```

`dataset-read-urls`

```bash
curl -i \
  -X POST "https://<project>.supabase.co/functions/v1/dataset-read-urls" \
  -H "Authorization: Bearer <JWT>" \
  -H "Content-Type: application/json" \
  -d '{"dataset_id":"<DATASET_ID>"}'
```